### PR TITLE
Fix x64/Debug build on MSVS

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1459,7 +1459,7 @@ static void logging_fail() {
 #if defined(_DEBUG) && defined(_MSC_VER)
   // When debugging on windows, avoid the obnoxious dialog and make
   // it possible to continue past a LOG(FATAL) in the debugger
-  _asm int 3
+  __debugbreak();
 #else
   abort();
 #endif


### PR DESCRIPTION
This fixes building glog on Windows using the Debug configuration on the x64 platform.