### PR TITLE
Adds color support for tmux

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -253,6 +253,7 @@ static bool TerminalSupportsColor() {
       !strcmp(term, "xterm") ||
       !strcmp(term, "xterm-color") ||
       !strcmp(term, "xterm-256color") ||
+      !strcmp(term, "screen-256color") ||
       !strcmp(term, "screen") ||
       !strcmp(term, "linux") ||
       !strcmp(term, "cygwin");


### PR DESCRIPTION
Even with 256 color support enabled in tmux, glog previously would only render plain text.  This pull request adds glog color support for 256 color tmux terminals.