### PR TITLE
Adds color output support for tmux terminals

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -253,6 +253,7 @@ static bool TerminalSupportsColor() {
       !strcmp(term, "xterm") ||
       !strcmp(term, "xterm-color") ||
       !strcmp(term, "xterm-256color") ||
+      !strcmp(term, "screen-256color") ||
       !strcmp(term, "screen") ||
       !strcmp(term, "linux") ||
       !strcmp(term, "cygwin");


### PR DESCRIPTION
Glog did not recognize the 256 color tmux terminal as "color enabled" via the TerminalSupportsCollor() method.  This pull request adds that support.