### PR TITLE
CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ check_function_exists (sigaction HAVE_SIGACTION)
 check_function_exists (sigaltstack HAVE_SIGALSTACK)
 
 check_cxx_compiler_flag (-Wno-deprecated HAVE_NO_DEPRECATED)
+check_cxx_compiler_flag (-Wno-unnamed-type-template-args
+    HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
 
 # NOTE: Cannot use check_function_exists here since >=vc-14.0 can define
 # snprintf as an inline function
@@ -360,6 +362,10 @@ if (WIN32 AND HAVE_SNPRINTF)
   set_property (SOURCE src/windows/port.cc APPEND PROPERTY COMPILE_DEFINITIONS
     HAVE_SNPRINTF)
 endif (WIN32 AND HAVE_SNPRINTF)
+
+if (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
+  target_compile_options (glog PUBLIC -Wno-unnamed-type-template-args)
+endif (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
 
 if (gflags_FOUND)
   target_include_directories (glog PUBLIC ${gflags_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,11 @@ endif (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
 if (gflags_FOUND)
   target_include_directories (glog PUBLIC ${gflags_INCLUDE_DIR})
   target_link_libraries (glog PUBLIC ${gflags_LIBRARIES})
+
+  if (NOT BUILD_SHARED_LIBS)
+    # Don't use __declspec(dllexport|dllimport) if this is a static build
+    targeT_compile_definitions (glog PUBLIC GFLAGS_DLL_DECLARE_FLAG= GFLAGS_DLL_DEFINE_FLAG=)
+  endif (NOT BUILD_SHARED_LIBS)
 endif (gflags_FOUND)
 
 set_target_properties (glog PROPERTIES VERSION ${GLOG_MAJOR_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,562 @@
+cmake_minimum_required (VERSION 3.0)
+
+if (POLICY CMP0042)
+  cmake_policy (SET CMP0042 NEW)
+endif (POLICY CMP0042)
+
+project (google-glog)
+
+enable_testing ()
+
+set (GLOG_MAJOR_VERSION 0)
+set (GLOG_MINOR_VERSION 3)
+set (GLOG_PATCH_VERSION 4)
+
+set (GLOG_VERSION
+  ${GLOG_MAJOR_VERSION}.${GLOG_MINOR_VERSION}.${GLOG_PATCH_VERSION})
+
+set (CPACK_PACKAGE_NAME glog)
+set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "")
+set (CPACK_PACKAGE_VERSION_MAJOR ${GLOG_MAJOR_VERSION})
+set (CPACK_PACKAGE_VERSION_MINOR ${GLOG_MINOR_VERSION})
+set (CPACK_PACKAGE_VERSION_PATCH ${GLOG_PATCH_VERSION})
+set (CPACK_PACKAGE_VERSION ${GLOG_VERSION})
+
+option (WITH_GFLAGS "Use gflags" ON)
+
+include (CMakePackageConfigHelpers)
+include (CPack)
+include (CheckCSourceCompiles)
+include (CheckCXXCompilerFlag)
+include (CheckCXXSourceCompiles)
+include (CheckFunctionExists)
+include (CheckIncludeFile)
+include (CheckIncludeFileCXX)
+include (CheckLibraryExists)
+include (CheckStructHasMember)
+include (CheckSymbolExists)
+include (CheckTypeSize)
+
+set (CMAKE_THREAD_PREFER_PTHREAD 1)
+
+if (WITH_GFLAGS)
+  find_package (gflags)
+
+  if (gflags_FOUND)
+    set (HAVE_LIB_GFLAGS 1)
+  endif (gflags_FOUND)
+endif (WITH_GFLAGS)
+
+find_package (Threads)
+
+check_include_file (dlfcn.h HAVE_DLFCN_H)
+check_include_file (execinfo.h HAVE_EXECINFO_H)
+check_include_file (glob.h HAVE_GLOB_H)
+check_include_file (inttypes.h HAVE_INTTYPES_H)
+check_include_file (libunwind.h HAVE_LIBUNWIND_H)
+check_include_file (memory.h HAVE_MEMORY_H)
+check_include_file (pwd.h HAVE_PWD_H)
+check_include_file (stdint.h HAVE_STDINT_H)
+check_include_file (stdlib.h HAVE_STDLIB_H)
+check_include_file (string.h HAVE_STRING_H)
+check_include_file (strings.h HAVE_STRINGS_H)
+check_include_file (sys/stat.h HAVE_SYS_STAT_H)
+check_include_file (sys/syscall.h HAVE_SYS_SYSCALL_H)
+check_include_file (sys/time.h HAVE_SYS_TIME_H)
+check_include_file (sys/types.h HAVE_SYS_TYPES_H)
+check_include_file (sys/utsname.h HAVE_SYS_UTSNAME_H)
+check_include_file (syscall.h HAVE_SYSCALL_H)
+check_include_file (syslog.h HAVE_SYSLOG_H)
+check_include_file (ucontext.h HAVE_UCONTEXT_H)
+check_include_file (unistd.h HAVE_UNISTD_H)
+check_include_file (unwind.h HAVE_UNWIND_H)
+
+check_include_file_cxx ("ext/hash_map" HAVE_EXT_HASH_MAP)
+check_include_file_cxx ("ext/hash_set" HAVE_EXT_HASH_SET)
+check_include_file_cxx ("ext/slist" HAVE_EXT_SLIST)
+check_include_file_cxx ("tr1/unordered_map" HAVE_TR1_UNORDERED_MAP)
+check_include_file_cxx ("tr1/unordered_set" HAVE_TR1_UNORDERED_SET)
+check_include_file_cxx ("unordered_map" HAVE_UNORDERED_MAP)
+check_include_file_cxx ("unordered_set" HAVE_UNORDERED_SET)
+
+check_type_size ("unsigned __int16" HAVE___UINT16)
+check_type_size (u_int16_t HAVE_U_INT16_T)
+check_type_size (uint16_t HAVE_UINT16_T)
+
+check_function_exists (dladdr HAVE_DLADDR)
+check_function_exists (fcntl HAVE_FCNTL)
+check_function_exists (pread HAVE_PREAD)
+check_function_exists (pwrite HAVE_PWRITE)
+check_function_exists (sigaction HAVE_SIGACTION)
+check_function_exists (sigaltstack HAVE_SIGALSTACK)
+
+check_cxx_compiler_flag (-Wno-deprecated HAVE_NO_DEPRECATED)
+
+# NOTE: Cannot use check_function_exists here since >=vc-14.0 can define
+# snprintf as an inline function
+check_symbol_exists (snprintf stdio.h HAVE_SNPRINTF)
+
+check_library_exists (unwind get_static_proc_name "" HAVE_LIB_UNWIND)
+
+check_c_source_compiles ("
+#include <stdlib.h>
+static void foo(void) __attribute__ ((unused));
+int main(void) { return 0; }
+" HAVE___ATTRIBUTE__)
+
+check_c_source_compiles ("
+#include <stdlib.h>
+static void foo(void) __attribute__ ((visibility(\"default\")));
+int main(void) { return 0; }
+" HAVE___ATTRIBUTE__VISIBILITY_DEFAULT)
+
+check_c_source_compiles ("
+#include <stdlib.h>
+static void foo(void) __attribute__ ((visibility(\"hidden\")));
+int main(void) { return 0; }
+" HAVE___ATTRIBUTE__VISIBILITY_HIDDEN)
+
+check_c_source_compiles ("
+int main(void) { if (__builtin_expect(0, 0)) return 1; return 0; }
+" HAVE___BUILTIN_EXPECT)
+
+check_c_source_compiles ("
+int main(void)
+{
+  int a; if (__sync_val_compare_and_swap(&a, 0, 1)) return 1; return 0;
+}
+" HAVE___SYNC_VAL_COMPARE_AND_SWAP)
+
+check_c_source_compiles ("
+#define _XOPEN_SOURCE 500
+#include <pthread.h>
+int main(void)
+{
+  pthread_rwlock_t l;
+  pthread_rwlock_init(&l, NULL);
+  pthread_rwlock_rdlock(&l);
+  return 0;
+}
+" HAVE_RWLOCK)
+
+check_c_source_compiles ("
+__declspec(selectany) int a;
+int main(void) { return 0; }
+" HAVE___DECLSPEC)
+
+check_cxx_source_compiles ("
+#include <vector>
+vector<int> t; int main() { }
+" STL_NO_NAMESPACE)
+
+check_cxx_source_compiles ("
+#include <vector>
+std::vector<int> t; int main() { }
+" STL_STD_NAMESPACE)
+
+check_cxx_source_compiles ("
+#include <iostream>
+std::ostream& operator<<(std::ostream&, struct s);
+using ::operator<<;
+int main() { }
+" HAVE_USING_OPERATOR)
+
+check_cxx_source_compiles ("
+namespace Outer { namespace Inner { int i = 0; }}
+using namespace Outer::Inner;;
+int main() { return i; }
+" HAVE_NAMESPACES)
+
+set (_PC_FIELDS
+  "gregs[REG_PC]"
+  "gregs[REG_EIP]"
+  "gregs[REG_RIP]"
+  "sc_ip"
+  "uc_regs->gregs[PT_NIP]"
+  "gregs[R15]"
+  "arm_pc"
+  "mc_eip"
+  "mc_rip"
+  "__gregs[REG_EIP]"
+  "__gregs[REG_RIP]"
+  "ss.eip"
+  "__ss.__eip"
+  "ss.rip"
+  "__ss.__rip"
+  "ss.srr0"
+  "__ss.__srr0"
+)
+
+set (_PC_HEADERS ucontext.h signal.h)
+
+if (HAVE_UCONTEXT_H AND NOT PC_FROM_UCONTEXT)
+  foreach (_PC_FIELD ${_PC_FIELDS})
+    foreach (_PC_HEADER ${_PC_HEADERS})
+      set (_TMP
+      ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/uctfield.c)
+      file (WRITE ${_TMP} "
+#define _GNU_SOURCE 1
+#include <${_PC_HEADER}>
+int main(void)
+{
+  ucontext_t u;
+  return u.${_PC_FIELD} == 0;
+}
+")
+      try_compile (HAVE_PC_FROM_UCONTEXT ${CMAKE_CURRENT_BINARY_DIR} ${_TMP}
+        COMPILE_DEFINITIONS _GNU_SOURCE=1)
+
+      if (HAVE_PC_FROM_UCONTEXT)
+        set (PC_FROM_UCONTEXT ${_PC_FIELD} CACHE)
+      endif (HAVE_PC_FROM_UCONTEXT)
+    endforeach (_PC_HEADER)
+  endforeach (_PC_FIELD)
+endif  (HAVE_UCONTEXT_H AND NOT PC_FROM_UCONTEXT)
+
+if (STL_STD_NAMESPACE)
+  set (STL_NAMESPACE std)
+else (STL_STD_NAMESPACE)
+  set (STL_NAMESPACE "")
+endif (STL_STD_NAMESPACE)
+
+set (GOOGLE_NAMESPACE google)
+set (_START_GOOGLE_NAMESPACE_ "namespace ${GOOGLE_NAMESPACE} {")
+set (_END_GOOGLE_NAMESPACE_ "}")
+
+if (HAVE___UINT16)
+  set (ac_cv_have___uint16 1)
+else (HAVE___UINT16)
+  set (ac_cv_have___uint16 0)
+endif (HAVE___UINT16)
+
+if (HAVE_INTTYPES_H)
+  set (ac_cv_have_inttypes_h 1)
+else (HAVE_INTTYPES_H)
+  set (ac_cv_have_inttypes_h 0)
+endif (HAVE_INTTYPES_H)
+
+if (HAVE_LIB_GFLAGS)
+  set (ac_cv_have_libgflags 1)
+else (HAVE_LIB_GFLAGS)
+  set (ac_cv_have_libgflags 0)
+endif (HAVE_LIB_GFLAGS)
+
+if (HAVE_STDINT_H)
+  set (ac_cv_have_stdint_h 1)
+else (HAVE_STDINT_H)
+  set (ac_cv_have_stdint_h 0)
+endif (HAVE_STDINT_H)
+
+if (HAVE_SYS_TYPES_H)
+  set (ac_cv_have_systypes_h 1)
+else (HAVE_SYS_TYPES_H)
+  set (ac_cv_have_systypes_h 0)
+endif (HAVE_SYS_TYPES_H)
+
+if (HAVE_U_INT16_T)
+  set (ac_cv_have_u_int16_t 1)
+else (HAVE_U_INT16_T)
+  set (ac_cv_have_u_int16_t 0)
+endif (HAVE_U_INT16_T)
+
+if (HAVE_UINT16_T)
+  set (ac_cv_have_uint16_t 1)
+else (HAVE_UINT16_T)
+  set (ac_cv_have_uint16_t 0)
+endif (HAVE_UINT16_T)
+
+if (HAVE_UNISTD_H)
+  set (ac_cv_have_unistd_h 1)
+else (HAVE_UNISTD_H)
+  set (ac_cv_have_unistd_h 0)
+endif (HAVE_UNISTD_H)
+
+set (ac_google_namespace ${GOOGLE_NAMESPACE})
+set (ac_google_end_namespace ${_END_GOOGLE_NAMESPACE_})
+set (ac_google_start_namespace ${_START_GOOGLE_NAMESPACE_})
+
+if (HAVE___ATTRIBUTE__)
+  set (ac_cv___attribute___noreturn "__attribute__((noreturn))")
+  set (ac_cv___attribute___noinline "__attribute__((noinline))")
+elseif (HAVE___DECLSPEC)
+  set (ac_cv___attribute___noreturn "__declspec(noreturn)")
+  #set (ac_cv___attribute___noinline "__declspec(noinline)")
+endif (HAVE___ATTRIBUTE__)
+
+if (HAVE___BUILTIN_EXPECT)
+  set (ac_cv_have___builtin_expect 1)
+else (HAVE___BUILTIN_EXPECT)
+  set (ac_cv_have___builtin_expect 0)
+endif (HAVE___BUILTIN_EXPECT)
+
+if (HAVE_USING_OPERATOR)
+  set (ac_cv_cxx_using_operator 1)
+else (HAVE_USING_OPERATOR)
+  set (ac_cv_cxx_using_operator 0)
+endif (HAVE_USING_OPERATOR)
+
+set (SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+
+if (Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)
+  set (HAVE_PTHREAD 1)
+endif (Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)
+
+set (TEST_SRC_DIR \"${CMAKE_CURRENT_SOURCE_DIR}\")
+
+configure_file (src/config.h.cmake.in config.h)
+configure_file (src/glog/logging.h.in glog/logging.h @ONLY)
+configure_file (src/glog/raw_logging.h.in glog/raw_logging.h @ONLY)
+configure_file (src/glog/stl_logging.h.in glog/stl_logging.h @ONLY)
+configure_file (src/glog/vlog_is_on.h.in glog/vlog_is_on.h @ONLY)
+
+set (CMAKE_CXX_VISIBILITY_PRESET default)
+set (CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
+set (GLOG_PUBLIC_H
+  ${CMAKE_CURRENT_BINARY_DIR}/config.h
+  ${CMAKE_CURRENT_BINARY_DIR}/glog/logging.h
+  ${CMAKE_CURRENT_BINARY_DIR}/glog/raw_logging.h
+  ${CMAKE_CURRENT_BINARY_DIR}/glog/stl_logging.h
+  ${CMAKE_CURRENT_BINARY_DIR}/glog/vlog_is_on.h
+  src/glog/log_severity.h
+)
+
+set (GLOG_SRCS
+  ${GLOG_PUBLIC_H}
+  src/base/commandlineflags.h
+  src/base/googleinit.h
+  src/base/mutex.h
+  src/demangle.cc
+  src/demangle.h
+  src/logging.cc
+  src/raw_logging.cc
+  src/symbolize.cc
+  src/symbolize.h
+  src/utilities.cc
+  src/utilities.h
+  src/vlog_is_on.cc
+)
+
+if (HAVE_PTHREAD)
+  list (APPEND GLOG_SRCS src/signalhandler.cc)
+endif (HAVE_PTHREAD)
+
+if (WIN32)
+  list (APPEND GLOG_SRCS
+    src/windows/port.cc
+    src/windows/port.h
+  )
+endif (WIN32)
+
+add_library (glog
+  ${GLOG_SRCS}
+)
+
+if (WIN32 AND HAVE_SNPRINTF)
+  set_property (SOURCE src/windows/port.cc APPEND PROPERTY COMPILE_DEFINITIONS
+    HAVE_SNPRINTF)
+endif (WIN32 AND HAVE_SNPRINTF)
+
+if (gflags_FOUND)
+  target_include_directories (glog PUBLIC ${gflags_INCLUDE_DIR})
+  target_link_libraries (glog PUBLIC ${gflags_LIBRARIES})
+endif (gflags_FOUND)
+
+set_target_properties (glog PROPERTIES VERSION ${GLOG_MAJOR_VERSION})
+set_target_properties (glog PROPERTIES SOVERSION ${GLOG_VERSION})
+
+if (WIN32)
+  target_compile_definitions (glog PUBLIC GLOG_NO_ABBREVIATED_SEVERITIES)
+endif (WIN32)
+
+set_target_properties (glog PROPERTIES PUBLIC_HEADER "${GLOG_PUBLIC_H}")
+
+target_include_directories (glog BEFORE PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+if (WIN32)
+  target_include_directories (glog PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/windows>"
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/windows)
+endif (WIN32)
+
+set_target_properties (glog PROPERTIES DEFINE_SYMBOL LIBGLOG_EXPORTS)
+
+if (NOT BUILD_SHARED_LIBS)
+  target_compile_definitions (glog PUBLIC GOOGLE_GLOG_DLL_DECL=)
+else (NOT BUILD_SHARED_LIBS)
+  target_compile_definitions (glog PRIVATE GOOGLE_GLOG_IS_A_DLL=1)
+
+  if (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT)
+    set (_EXPORT "__attribute__((visibility(\"default\")))")
+    set (_IMPORT "")
+  elseif (HAVE___DECLSPEC)
+    set (_EXPORT "__declspec(dllexport)")
+    set (_IMPORT "__declspec(dllimport)")
+  endif (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT)
+
+  target_compile_definitions (glog PRIVATE
+    "GOOGLE_GLOG_DLL_DECL=${_EXPORT}")
+  target_compile_definitions (glog INTERFACE
+    "GOOGLE_GLOG_DLL_DECL=${_IMPORT}")
+  target_compile_definitions (glog INTERFACE
+    "GOOGLE_GLOG_DLL_DECL_FOR_UNITTESTS=${_IMPORT}")
+endif (NOT BUILD_SHARED_LIBS)
+
+if (HAVE_PTHREAD)
+  target_link_libraries (glog PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+else (HAVE_PTHREAD)
+  target_compile_definitions (glog PUBLIC NO_THREADS)
+endif (HAVE_PTHREAD)
+
+if (HAVE_EXECINFO_H)
+  set (HAVE_STACKTRACE 1)
+endif (HAVE_EXECINFO_H)
+
+if (UNIX OR (APPLE AND HAVE_DLADDR))
+  set (HAVE_SYMBOLIZE 1)
+endif (UNIX OR (APPLE AND HAVE_DLADDR))
+
+# Unit testing
+
+add_executable (logging_unittest
+  src/logging_unittest.cc
+)
+
+target_link_libraries (logging_unittest PRIVATE glog)
+
+add_executable (stl_logging_unittest
+  src/stl_logging_unittest.cc
+)
+
+target_link_libraries (stl_logging_unittest PRIVATE glog)
+
+if (HAVE_NO_DEPRECATED)
+  set_property (TARGET stl_logging_unittest APPEND PROPERTY COMPILE_OPTIONS
+    -Wno-deprecated)
+endif (HAVE_NO_DEPRECATED)
+
+if (HAVE_UNORDERED_MAP AND HAVE_UNORDERED_SET)
+  target_compile_definitions (stl_logging_unittest PRIVATE
+    GLOG_STL_LOGGING_FOR_UNORDERED)
+endif (HAVE_UNORDERED_MAP AND HAVE_UNORDERED_SET)
+
+if (HAVE_TR1_UNORDERED_MAP AND HAVE_TR1_UNORDERED_SET)
+  target_compile_definitions (stl_logging_unittest PRIVATE
+    GLOG_STL_LOGGING_FOR_TR1_UNORDERED)
+endif (HAVE_TR1_UNORDERED_MAP AND HAVE_TR1_UNORDERED_SET)
+
+if (HAVE_EXT_HASH_MAP AND HAVE_EXT_HASH_SET)
+  target_compile_definitions (stl_logging_unittest PRIVATE
+    GLOG_STL_LOGGING_FOR_EXT_HASH)
+endif (HAVE_EXT_HASH_MAP AND HAVE_EXT_HASH_SET)
+
+if (HAVE_EXT_SLIST)
+  target_compile_definitions (stl_logging_unittest PRIVATE
+    GLOG_STL_LOGGING_FOR_EXT_SLIST)
+endif (HAVE_EXT_SLIST)
+
+if (HAVE_SYMBOLIZE)
+  add_executable (symbolize_unittest
+    src/symbolize_unittest.cc
+  )
+
+  target_link_libraries (symbolize_unittest PRIVATE glog)
+endif (HAVE_SYMBOLIZE)
+
+add_executable (demangle_unittest
+  src/demangle_unittest.cc
+)
+
+target_link_libraries (demangle_unittest PRIVATE glog)
+
+if (HAVE_STACKTRACE)
+  add_executable (stacktrace_unittest
+    src/stacktrace_unittest.cc
+  )
+
+  target_link_libraries (stacktrace_unittest PRIVATE glog)
+endif (HAVE_STACKTRACE)
+
+add_executable (utilities_unittest
+  src/utilities_unittest.cc
+)
+
+target_link_libraries (utilities_unittest PRIVATE glog)
+
+if (HAVE_STACKTRACE AND HAVE_SYMBOLIZE)
+  add_executable (signalhandler_unittest
+    src/signalhandler_unittest.cc
+  )
+
+  target_link_libraries (signalhandler_unittest PRIVATE glog)
+endif (HAVE_STACKTRACE AND HAVE_SYMBOLIZE)
+
+add_test (NAME demangle COMMAND demangle_unittest)
+add_test (NAME logging COMMAND logging_unittest)
+
+if (TARGET signalhandler_unittest)
+  add_test (NAME signalhandler COMMAND signalhandler_unittest)
+endif (TARGET signalhandler_unittest)
+
+if (TARGET stacktrace_unittest)
+  add_test (NAME stacktrace COMMAND stacktrace_unittest)
+endif (TARGET stacktrace_unittest)
+
+add_test (NAME stl_logging COMMAND stl_logging_unittest)
+
+if (TARGET symbolize_unittest)
+  add_test (NAME symbolize COMMAND symbolize_unittest)
+endif (TARGET symbolize_unittest)
+
+install (TARGETS glog
+  EXPORT glog-targets
+  RUNTIME DESTINATION bin
+  PUBLIC_HEADER DESTINATION include/glog
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)
+
+# Build tree config
+
+set (glog_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
+set (glog_PACKAGE_DEPS)
+
+if (gflags_FOUND)
+  set (glog_PACKAGE_DEPS
+"
+include (CMakeFindDependencyMacro)
+
+find_dependency (gflags ${gflags_VERSION})
+")
+endif (gflags_FOUND)
+
+configure_package_config_file (glog-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/glog-config.cmake INSTALL_DESTINATION
+  lib/cmake/glog PATH_VARS glog_INCLUDE_DIR
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+# The version file is the same both for build tree and install mode config
+write_basic_package_version_file (glog-config-version.cmake VERSION
+  ${GLOG_VERSION} COMPATIBILITY SameMajorVersion)
+
+# Install config
+
+set (glog_INCLUDE_DIR include)
+
+configure_package_config_file (glog-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/glog-config.cmake
+  INSTALL_DESTINATION lib/cmake/glog PATH_VARS glog_INCLUDE_DIR
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+
+export (TARGETS glog FILE glog-targets.cmake)
+export (PACKAGE glog)
+
+install (FILES
+  ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/glog-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/glog-config-version.cmake
+  DESTINATION lib/cmake/glog)
+
+install (EXPORT glog-targets DESTINATION lib/cmake/glog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ set (CPACK_PACKAGE_VERSION ${GLOG_VERSION})
 
 option (WITH_GFLAGS "Use gflags" ON)
 
+list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
 include (CMakePackageConfigHelpers)
 include (CPack)
 include (CheckCSourceCompiles)
@@ -36,6 +38,7 @@ include (CheckLibraryExists)
 include (CheckStructHasMember)
 include (CheckSymbolExists)
 include (CheckTypeSize)
+include (DetermineGflagsNamespace)
 
 set (CMAKE_THREAD_PREFER_PTHREAD 1)
 
@@ -44,6 +47,7 @@ if (WITH_GFLAGS)
 
   if (gflags_FOUND)
     set (HAVE_LIB_GFLAGS 1)
+    determine_gflags_namespace (gflags_NAMESPACE)
   endif (gflags_FOUND)
 endif (WITH_GFLAGS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,9 @@ check_symbol_exists (snprintf stdio.h HAVE_SNPRINTF)
 
 check_library_exists (unwind get_static_proc_name "" HAVE_LIB_UNWIND)
 
+find_library (UNWIND_LIBRARY NAMES unwind DOC "unwind library")
+mark_as_advanced (UNWIND_LIBRARY)
+
 check_c_source_compiles ("
 #include <stdlib.h>
 static void foo(void) __attribute__ ((unused));
@@ -357,6 +360,10 @@ endif (WIN32)
 add_library (glog
   ${GLOG_SRCS}
 )
+
+if (UNWIND_LIBRARY)
+  target_link_libraries (glog PUBLIC ${UNWIND_LIBRARY})
+endif (UNWIND_LIBRARY)
 
 if (WIN32 AND HAVE_SNPRINTF)
   set_property (SOURCE src/windows/port.cc APPEND PROPERTY COMPILE_DEFINITIONS

--- a/cmake/DetermineGflagsNamespace.cmake
+++ b/cmake/DetermineGflagsNamespace.cmake
@@ -1,0 +1,69 @@
+macro(determine_gflags_namespace VARIABLE)
+  if (NOT DEFINED "${VARIABLE}")
+    if (CMAKE_REQUIRED_INCLUDES)
+      set (CHECK_INCLUDE_FILE_CXX_INCLUDE_DIRS "-DINCLUDE_DIRECTORIES=${CMAKE_REQUIRED_INCLUDES}")
+    else ()
+      set (CHECK_INCLUDE_FILE_CXX_INCLUDE_DIRS)
+    endif ()
+
+    set(MACRO_CHECK_INCLUDE_FILE_FLAGS ${CMAKE_REQUIRED_FLAGS})
+
+    set(_NAMESPACES gflags google)
+    set(_check_code
+"
+#include <gflags/gflags.h>
+
+int main(int argc, char**argv)
+{
+  GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
+}
+")
+    if (NOT CMAKE_REQUIRED_QUIET)
+      message (STATUS "Looking for gflags namespace")
+    endif ()
+    if (${ARGC} EQUAL 3)
+      set (CMAKE_CXX_FLAGS_SAVE ${CMAKE_CXX_FLAGS})
+      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARGV2}")
+    endif ()
+
+    set (_check_file
+        ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/DetermineGflagsNamespace.cxx)
+
+    foreach (_namespace ${_NAMESPACES})
+      file (WRITE "${_check_file}" "${_check_code}")
+      try_compile (${VARIABLE}
+        "${CMAKE_BINARY_DIR}" "${_check_file}"
+        COMPILE_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}" -DGFLAGS_NAMESPACE=${_namespace}
+        LINK_LIBRARIES "${gflags_LIBRARIES}"
+        CMAKE_FLAGS -DINCLUDE_DIRECTORIES:STRING="${gflags_INCLUDE_DIR}"
+        OUTPUT_VARIABLE OUTPUT)
+
+      if (${VARIABLE})
+        set (${VARIABLE} ${_namespace} CACHE INTERNAL "gflags namespace" FORCE)
+        break ()
+      else ()
+        file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+          "Determining the gflags namespace ${_namespace} failed with the following output:\n"
+          "${OUTPUT}\n\n")
+      endif ()
+    endforeach (_namespace)
+
+    if (${ARGC} EQUAL 3)
+      set (CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_SAVE})
+    endif ()
+
+    if (${VARIABLE})
+      if (NOT CMAKE_REQUIRED_QUIET)
+        message (STATUS "Looking for gflags namespace - ${${VARIABLE}}")
+      endif ()
+      file (APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeOutput.log
+        "Determining the gflags namespace passed with the following output:\n"
+        "${OUTPUT}\n\n")
+    else ()
+      if (NOT CMAKE_REQUIRED_QUIET)
+        message (STATUS "Looking for gflags namespace - failed")
+      endif ()
+      set (${VARIABLE} ${_namespace} CACHE INTERNAL "gflags namespace")
+    endif ()
+  endif ()
+endmacro ()

--- a/glog-config.cmake.in
+++ b/glog-config.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+include ("${CMAKE_CURRENT_LIST_DIR}/glog-targets.cmake")
+set_and_check (glog_INCLUDE_DIR "@PACKAGE_glog_INCLUDE_DIR@")
+
+@glog_PACKAGE_DEPS@
+
+set (glog_LIBRARY glog)
+
+set (glog_LIBRARIES ${glog_LIBRARY})
+set (glog_INCLUDE_DIRS ${glog_INCLUDE_DIR})

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -1,189 +1,181 @@
-/* src/config.h.in.  Generated from configure.ac by autoheader.  */
-
 /* define if glog doesn't use RTTI */
-#undef DISABLE_RTTI
+#cmakedefine DISABLE_RTTI
 
 /* Namespace for Google classes */
-#undef GOOGLE_NAMESPACE
+#cmakedefine GOOGLE_NAMESPACE ${GOOGLE_NAMESPACE}
 
 /* Define if you have the `dladdr' function */
-#undef HAVE_DLADDR
+#cmakedefine HAVE_DLADDR
+
+/* Define if you have the `snprintf' function */
+#cmakedefine HAVE_SNPRINTF
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#undef HAVE_DLFCN_H
+#cmakedefine HAVE_DLFCN_H
 
 /* Define to 1 if you have the <execinfo.h> header file. */
-#undef HAVE_EXECINFO_H
+#cmakedefine HAVE_EXECINFO_H
 
 /* Define if you have the `fcntl' function */
-#undef HAVE_FCNTL
+#cmakedefine HAVE_FCNTL
 
 /* Define to 1 if you have the <glob.h> header file. */
-#undef HAVE_GLOB_H
+#cmakedefine HAVE_GLOB_H
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-#undef HAVE_INTTYPES_H
+#cmakedefine HAVE_INTTYPES_H ${HAVE_INTTYPES_H}
 
 /* Define to 1 if you have the `pthread' library (-lpthread). */
-#undef HAVE_LIBPTHREAD
+#cmakedefine HAVE_LIBPTHREAD
 
 /* Define to 1 if you have the <libunwind.h> header file. */
-#undef HAVE_LIBUNWIND_H
+#cmakedefine HAVE_LIBUNWIND_H
 
 /* define if you have google gflags library */
-#undef HAVE_LIB_GFLAGS
+#cmakedefine HAVE_LIB_GFLAGS
 
 /* define if you have google gmock library */
-#undef HAVE_LIB_GMOCK
+#cmakedefine HAVE_LIB_GMOCK
 
 /* define if you have google gtest library */
-#undef HAVE_LIB_GTEST
+#cmakedefine HAVE_LIB_GTEST
 
 /* define if you have libunwind */
-#undef HAVE_LIB_UNWIND
+#cmakedefine HAVE_LIB_UNWIND
 
 /* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
+#cmakedefine HAVE_MEMORY_H
 
 /* define if the compiler implements namespaces */
-#undef HAVE_NAMESPACES
+#cmakedefine HAVE_NAMESPACES
 
 /* Define if you have the 'pread' function */
-#undef HAVE_PREAD
+#cmakedefine HAVE_PREAD
 
 /* Define if you have POSIX threads libraries and header files. */
-#undef HAVE_PTHREAD
+#cmakedefine HAVE_PTHREAD
 
 /* Define to 1 if you have the <pwd.h> header file. */
-#undef HAVE_PWD_H
+#cmakedefine HAVE_PWD_H
 
 /* Define if you have the 'pwrite' function */
-#undef HAVE_PWRITE
+#cmakedefine HAVE_PWRITE
 
 /* define if the compiler implements pthread_rwlock_* */
-#undef HAVE_RWLOCK
+#cmakedefine HAVE_RWLOCK
 
 /* Define if you have the 'sigaction' function */
-#undef HAVE_SIGACTION
+#cmakedefine HAVE_SIGACTION
 
 /* Define if you have the `sigaltstack' function */
-#undef HAVE_SIGALTSTACK
+#cmakedefine HAVE_SIGALTSTACK
 
 /* Define to 1 if you have the <stdint.h> header file. */
-#undef HAVE_STDINT_H
+#cmakedefine HAVE_STDINT_H ${HAVE_STDINT_H}
 
 /* Define to 1 if you have the <stdlib.h> header file. */
-#undef HAVE_STDLIB_H
+#cmakedefine HAVE_STDLIB_H
 
 /* Define to 1 if you have the <strings.h> header file. */
-#undef HAVE_STRINGS_H
+#cmakedefine HAVE_STRINGS_H
 
 /* Define to 1 if you have the <string.h> header file. */
-#undef HAVE_STRING_H
+#cmakedefine HAVE_STRING_H
 
 /* Define to 1 if you have the <syscall.h> header file. */
-#undef HAVE_SYSCALL_H
+#cmakedefine HAVE_SYSCALL_H
 
 /* Define to 1 if you have the <syslog.h> header file. */
-#undef HAVE_SYSLOG_H
+#cmakedefine HAVE_SYSLOG_H
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
-#undef HAVE_SYS_STAT_H
+#cmakedefine HAVE_SYS_STAT_H
 
 /* Define to 1 if you have the <sys/syscall.h> header file. */
-#undef HAVE_SYS_SYSCALL_H
+#cmakedefine HAVE_SYS_SYSCALL_H
 
 /* Define to 1 if you have the <sys/time.h> header file. */
-#undef HAVE_SYS_TIME_H
+#cmakedefine HAVE_SYS_TIME_H
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#undef HAVE_SYS_TYPES_H
+#cmakedefine HAVE_SYS_TYPES_H ${HAVE_SYS_TYPES_H}
 
 /* Define to 1 if you have the <sys/ucontext.h> header file. */
-#undef HAVE_SYS_UCONTEXT_H
+#cmakedefine HAVE_SYS_UCONTEXT_H
 
 /* Define to 1 if you have the <sys/utsname.h> header file. */
-#undef HAVE_SYS_UTSNAME_H
+#cmakedefine HAVE_SYS_UTSNAME_H
 
 /* Define to 1 if you have the <ucontext.h> header file. */
-#undef HAVE_UCONTEXT_H
+#cmakedefine HAVE_UCONTEXT_H
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#undef HAVE_UNISTD_H
+#cmakedefine HAVE_UNISTD_H ${HAVE_UNISTD_H}
 
 /* Define to 1 if you have the <unwind.h> header file. */
-#undef HAVE_UNWIND_H
+#cmakedefine HAVE_UNWIND_H ${HAVE_UNWIND_H}
 
 /* define if the compiler supports using expression for operator */
-#undef HAVE_USING_OPERATOR
+#cmakedefine HAVE_USING_OPERATOR
 
 /* define if your compiler has __attribute__ */
-#undef HAVE___ATTRIBUTE__
+#cmakedefine HAVE___ATTRIBUTE__
 
 /* define if your compiler has __builtin_expect */
-#undef HAVE___BUILTIN_EXPECT
+#cmakedefine HAVE___BUILTIN_EXPECT ${HAVE___BUILTIN_EXPECT}
 
 /* define if your compiler has __sync_val_compare_and_swap */
-#undef HAVE___SYNC_VAL_COMPARE_AND_SWAP
+#cmakedefine HAVE___SYNC_VAL_COMPARE_AND_SWAP
 
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
-#undef LT_OBJDIR
+#cmakedefine LT_OBJDIR
 
 /* Name of package */
-#undef PACKAGE
+#cmakedefine PACKAGE
 
 /* Define to the address where bug reports for this package should be sent. */
-#undef PACKAGE_BUGREPORT
+#cmakedefine PACKAGE_BUGREPORT
 
 /* Define to the full name of this package. */
-#undef PACKAGE_NAME
+#cmakedefine PACKAGE_NAME
 
 /* Define to the full name and version of this package. */
-#undef PACKAGE_STRING
+#cmakedefine PACKAGE_STRING
 
 /* Define to the one symbol short name of this package. */
-#undef PACKAGE_TARNAME
+#cmakedefine PACKAGE_TARNAME
 
 /* Define to the home page for this package. */
-#undef PACKAGE_URL
+#cmakedefine PACKAGE_URL
 
 /* Define to the version of this package. */
-#undef PACKAGE_VERSION
+#cmakedefine PACKAGE_VERSION
 
 /* How to access the PC from a struct ucontext */
-#undef PC_FROM_UCONTEXT
+#cmakedefine PC_FROM_UCONTEXT
 
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */
-#undef PTHREAD_CREATE_JOINABLE
+#cmakedefine PTHREAD_CREATE_JOINABLE
 
 /* The size of `void *', as computed by sizeof. */
-#undef SIZEOF_VOID_P
+#cmakedefine SIZEOF_VOID_P ${SIZEOF_VOID_P}
 
 /* Define to 1 if you have the ANSI C header files. */
-#undef STDC_HEADERS
+#cmakedefine STDC_HEADERS
 
 /* the namespace where STL code like vector<> is defined */
-#undef STL_NAMESPACE
+#cmakedefine STL_NAMESPACE ${STL_NAMESPACE}
 
 /* location of source code */
-#undef TEST_SRC_DIR
+#cmakedefine TEST_SRC_DIR ${TEST_SRC_DIR}
 
 /* Version number of package */
-#undef VERSION
+#cmakedefine VERSION
 
 /* Stops putting the code inside the Google namespace */
-#undef _END_GOOGLE_NAMESPACE_
+#cmakedefine _END_GOOGLE_NAMESPACE_ ${_END_GOOGLE_NAMESPACE_}
 
 /* Puts following code inside the Google namespace */
-#undef _START_GOOGLE_NAMESPACE_
-
-// Annoying stuff for windows -- makes sure clients can import these functions
-#ifndef GOOGLE_GLOG_DLL_DECL
-# if defined(_WIN32) && !defined(__CYGWIN__)
-#   define GOOGLE_GLOG_DLL_DECL  __declspec(dllimport)
-# else
-#   define GOOGLE_GLOG_DLL_DECL
-# endif
-#endif
+#cmakedefine _START_GOOGLE_NAMESPACE_ ${_START_GOOGLE_NAMESPACE_}

--- a/src/demangle.h
+++ b/src/demangle.h
@@ -77,7 +77,7 @@ _START_GOOGLE_NAMESPACE_
 // Demangle "mangled".  On success, return true and write the
 // demangled symbol name to "out".  Otherwise, return false.
 // "out" is modified even if demangling is unsuccessful.
-bool Demangle(const char *mangled, char *out, int out_size);
+bool GOOGLE_GLOG_DLL_DECL Demangle(const char *mangled, char *out, int out_size);
 
 _END_GOOGLE_NAMESPACE_
 

--- a/src/demangle_unittest.cc
+++ b/src/demangle_unittest.cc
@@ -41,6 +41,11 @@
 #include "googletest.h"
 #include "config.h"
 
+#ifdef HAVE_LIB_GFLAGS
+#include <gflags/gflags.h>
+using namespace GFLAGS_NAMESPACE;
+#endif
+
 GLOG_DEFINE_bool(demangle_filter, false,
                  "Run demangle_unittest in filter mode");
 

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1152,6 +1152,8 @@ public:
     char* str() const { return pbase(); }
 
   private:
+    LogStream(const LogStream&);
+    LogStream& operator=(const LogStream&);
     base_logging::LogStreamBuf streambuf_;
     int ctr_;  // Counter hack (for the LOG_EVERY_X() macro)
     LogStream *self_;  // Consistency check hack

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1219,7 +1219,7 @@ public:
   void SendToSyslogAndLog();  // Actually dispatch to syslog and the logs
 
   // Call abort() or similar to perform LOG(FATAL) crash.
-  static void Fail() @ac_cv___attribute___noreturn@;
+  static void @ac_cv___attribute___noreturn@ Fail();
 
   std::ostream& stream();
 
@@ -1267,7 +1267,7 @@ class GOOGLE_GLOG_DLL_DECL LogMessageFatal : public LogMessage {
  public:
   LogMessageFatal(const char* file, int line);
   LogMessageFatal(const char* file, int line, const CheckOpString& result);
-  ~LogMessageFatal() @ac_cv___attribute___noreturn@;
+  @ac_cv___attribute___noreturn@ ~LogMessageFatal();
 };
 
 // A non-macro interface to the log facility; (useful
@@ -1571,7 +1571,7 @@ class GOOGLE_GLOG_DLL_DECL NullStreamFatal : public NullStream {
   NullStreamFatal() { }
   NullStreamFatal(const char* file, int line, const CheckOpString& result) :
       NullStream(file, line, result) { }
-  @ac_cv___attribute___noreturn@ ~NullStreamFatal() { _exit(1); }
+  @ac_cv___attribute___noreturn@ ~NullStreamFatal() throw () { _exit(1); }
 };
 
 // Install a signal handler that will dump signal information and a stack

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -48,14 +48,6 @@
 #endif
 #include <vector>
 
-// Annoying stuff for windows -- makes sure clients can import these functions
-#ifndef GOOGLE_GLOG_DLL_DECL
-# if defined(_WIN32) && !defined(__CYGWIN__)
-#   define GOOGLE_GLOG_DLL_DECL  __declspec(dllimport)
-# else
-#   define GOOGLE_GLOG_DLL_DECL
-# endif
-#endif
 #if defined(_MSC_VER)
 #define GLOG_MSVC_PUSH_DISABLE_WARNING(n) __pragma(warning(push)) \
                                      __pragma(warning(disable:n))
@@ -63,6 +55,15 @@
 #else
 #define GLOG_MSVC_PUSH_DISABLE_WARNING(n)
 #define GLOG_MSVC_POP_WARNING()
+#endif
+
+// Annoying stuff for windows -- makes sure clients can import these functions
+#ifndef GOOGLE_GLOG_DLL_DECL
+# if defined(_WIN32) && !defined(__CYGWIN__)
+#   define GOOGLE_GLOG_DLL_DECL  __declspec(dllimport)
+# else
+#   define GOOGLE_GLOG_DLL_DECL
+# endif
 #endif
 
 // We care a lot about number of bits things take up.  Unfortunately,

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -81,7 +81,7 @@ static inline string GetTempDir() {
 #endif
 }
 
-#if defined(OS_WINDOWS) && defined(_MSC_VER)
+#if defined(OS_WINDOWS) && defined(_MSC_VER) && !defined(TEST_SRC_DIR)
 // The test will run in glog/vsproject/<project name>
 // (e.g., glog/vsproject/logging_unittest).
 static const char TEST_SRC_DIR[] = "../..";

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -61,6 +61,7 @@ DECLARE_string(log_backtrace_at);  // logging.cc
 
 #ifdef HAVE_LIB_GFLAGS
 #include <gflags/gflags.h>
+using namespace GFLAGS_NAMESPACE;
 #endif
 
 #ifdef HAVE_LIB_GMOCK

--- a/src/signalhandler_unittest.cc
+++ b/src/signalhandler_unittest.cc
@@ -41,6 +41,11 @@
 #include <string>
 #include "glog/logging.h"
 
+#ifdef HAVE_LIB_GFLAGS
+#include <gflags/gflags.h>
+using namespace gflags;
+#endif
+
 using namespace GOOGLE_NAMESPACE;
 
 void* DieInThread(void*) {

--- a/src/stl_logging_unittest.cc
+++ b/src/stl_logging_unittest.cc
@@ -31,6 +31,7 @@
 
 #ifdef HAVE_USING_OPERATOR
 
+#include <functional>
 #include <iostream>
 #include <map>
 #include <ostream>

--- a/src/stl_logging_unittest.cc
+++ b/src/stl_logging_unittest.cc
@@ -41,11 +41,19 @@
 // C++0x isn't enabled by default in GCC and libc++ does not have
 // non-standard ext/* and tr1/unordered_*.
 # if defined(_LIBCPP_VERSION)
+#  ifndef GLOG_STL_LOGGING_FOR_UNORDERED
 #  define GLOG_STL_LOGGING_FOR_UNORDERED
+#  endif
 # else
+#  ifndef GLOG_STL_LOGGING_FOR_EXT_HASH
 #  define GLOG_STL_LOGGING_FOR_EXT_HASH
+#  endif
+#  ifndef GLOG_STL_LOGGING_FOR_EXT_SLIST
 #  define GLOG_STL_LOGGING_FOR_EXT_SLIST
+#  endif
+#  ifndef GLOG_STL_LOGGING_FOR_TR1_UNORDERED
 #  define GLOG_STL_LOGGING_FOR_TR1_UNORDERED
+#  endif
 # endif
 #endif
 

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -41,6 +41,11 @@
 #include "googletest.h"
 #include "config.h"
 
+#ifdef HAVE_LIB_GFLAGS
+#include <gflags/gflags.h>
+using namespace GFLAGS_NAMESPACE;
+#endif
+
 using namespace std;
 using namespace GOOGLE_NAMESPACE;
 

--- a/src/utilities_unittest.cc
+++ b/src/utilities_unittest.cc
@@ -28,10 +28,14 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // Author: Shinichiro Hamaji
-
 #include "utilities.h"
 #include "googletest.h"
 #include "glog/logging.h"
+
+#ifdef HAVE_LIB_GFLAGS
+#include <gflags/gflags.h>
+using namespace GFLAGS_NAMESPACE;
+#endif
 
 using namespace GOOGLE_NAMESPACE;
 

--- a/src/windows/port.cc
+++ b/src/windows/port.cc
@@ -55,6 +55,7 @@ int safe_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
   return _vsnprintf(str, size-1, format, ap);
 }
 
+#ifndef HAVE_SNPRINTF
 int snprintf(char *str, size_t size, const char *format, ...) {
   va_list ap;
   va_start(ap, format);
@@ -62,3 +63,4 @@ int snprintf(char *str, size_t size, const char *format, ...) {
   va_end(ap);
   return r;
 }
+#endif

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -111,12 +111,16 @@ enum { STDIN_FILENO = 0, STDOUT_FILENO = 1, STDERR_FILENO = 2 };
  * because they don't always NUL-terminate. :-(  We also can't use the
  * name vsnprintf, since windows defines that (but not snprintf (!)).
  */
-extern int snprintf(char *str, size_t size,
+#ifndef HAVE_SNPRINTF
+extern int GOOGLE_GLOG_DLL_DECL snprintf(char *str, size_t size,
                                        const char *format, ...);
-extern int safe_vsnprintf(char *str, size_t size,
+#endif
+extern int GOOGLE_GLOG_DLL_DECL safe_vsnprintf(char *str, size_t size,
                           const char *format, va_list ap);
 #define vsnprintf(str, size, format, ap)  safe_vsnprintf(str, size, format, ap)
+#ifndef va_copy
 #define va_copy(dst, src)  (dst) = (src)
+#endif
 
 /* Windows doesn't support specifying the number of buckets as a
  * hash_map constructor arg, so we leave this blank.


### PR DESCRIPTION
This series of patches adds CMake support to glog and fixes several compilation issues.

My primary goal was to be able to compile glog on Windows using Visual Studio without any hassle. The modifications have been tested using VC 8.0 through VC 14.0 CTP 6, cygwin gcc 4.9.2, Intel C++ Compiler 15.0, Apple Clang, and on Arch Linux using gcc 4.9.2 and clang 3.6 (both static and shared builds).

``CMakeLists.txt`` also generates config files, which allow to use glog in CMake projects easily:

``` cmake
cmake_minimum_required (VERSION 2.8.11)
project (myproject)

find_package (glog 0.3.4)

add_executable (myproject myproject.cpp)
target_link_libraries (myproject glog)
```

To run the unit tests, execute:
``` bash
make test
```
when using the Makefiles generator.