### PR TITLE
LOG_STRING: use std::vector and std::string.

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -542,7 +542,7 @@ class LogSink;  // defined below
 //   vector<string> *outvec;
 // The cast is to disambiguate NULL arguments.
 #define LOG_STRING(severity, outvec) \
-  LOG_TO_STRING_##severity(static_cast<vector<string>*>(outvec)).stream()
+  LOG_TO_STRING_##severity(static_cast<std::vector<std::string>*>(outvec)).stream()
 
 #define LOG_IF(severity, condition) \
   !(condition) ? (void) 0 : @ac_google_namespace@::LogMessageVoidify() & LOG(severity)


### PR DESCRIPTION
Previously, plain vector and string were used.
This assumed that there were "using" directives or
declarations before the macro was used.  This will
not always be the case.