### PR TITLE
delete LogDestination::sinks_ at DeleteLogDestinations().

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -817,6 +817,11 @@ void LogDestination::DeleteLogDestinations() {
     delete log_destinations_[severity];
     log_destinations_[severity] = NULL;
   }
+  MutexLock l(&sink_mutex_);
+  for (size_t i = 0; i < sinks_->size(); ++i) {
+    delete (*sinks_)[i];
+  }
+  delete sinks_;
 }
 
 namespace {

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -818,9 +818,6 @@ void LogDestination::DeleteLogDestinations() {
     log_destinations_[severity] = NULL;
   }
   MutexLock l(&sink_mutex_);
-  for (size_t i = 0; i < sinks_->size(); ++i) {
-    delete (*sinks_)[i];
-  }
   delete sinks_;
 }
 


### PR DESCRIPTION
fixes #8 AddLogSink memory leak