### PR TITLE
[#23 #22] Allow a logfile mode and logfile date-naming

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -360,6 +360,12 @@ DECLARE_int32(minloglevel);
 // default logging directory.
 DECLARE_string(log_dir);
 
+// Set the log file mode.
+DECLARE_int32(logfile_mode);
+
+// Allow writing to the same logfile, using date-only broad suffixes.
+DECLARE_bool(usedatefilenames);
+
 // Sets the path of the directory into which to put additional links
 // to the log files.
 DECLARE_string(log_link);


### PR DESCRIPTION
Two features we've modded into https://github.com/facebook/osquery.git:

1. Write logs that may have sensitive content in warnings/errors as o600 instead of o644.
2. Write/append to a logfilename using the date as a suffix. If folks are pulling these files into an elk-stack or splunk, having a by-date file name from the project is a nicety! 

It would be great to have 1. in maintain so we can build a safe glog dependency in FreeBSD, where we construct our build hosts with ports. 2. is more of a like-to-have-- so I'm interested in other's thoughts.