### PR TITLE
[#23] Add logfile_mode to control logfile permissions

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -360,6 +360,9 @@ DECLARE_int32(minloglevel);
 // default logging directory.
 DECLARE_string(log_dir);
 
+// Set the log file mode.
+DECLARE_int32(logfile_mode);
+
 // Sets the path of the directory into which to put additional links
 // to the log files.
 DECLARE_string(log_link);

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -161,6 +161,8 @@ static const char* DefaultLogDir() {
   return "";
 }
 
+GLOG_DEFINE_int32(logfile_mode, 0664, "Log file mode/permissions.");
+
 GLOG_DEFINE_string(log_dir, DefaultLogDir(),
                    "If specified, logfiles are written into this directory instead "
                    "of the default logging directory.");
@@ -897,7 +899,7 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
   string string_filename = base_filename_+filename_extension_+
                            time_pid_string;
   const char* filename = string_filename.c_str();
-  int fd = open(filename, O_WRONLY | O_CREAT | O_EXCL, 0664);
+  int fd = open(filename, O_WRONLY | O_CREAT | O_EXCL, FLAGS_logfile_mode);
   if (fd == -1) return false;
 #ifdef HAVE_FCNTL
   // Mark the file close-on-exec. We don't really care if this fails


### PR DESCRIPTION
I'd like to set o600 for daemons writing potentially sensitive WARN/ERROR messages.