### PR TITLE
support for msvs 2015 RC

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -31,7 +31,6 @@
 
 #include "utilities.h"
 
-#include <algorithm>
 #include <assert.h>
 #include <iomanip>
 #include <string>
@@ -56,6 +55,7 @@
 # include <syslog.h>
 #endif
 #include <vector>
+#include <algorithm>   // order important for vs2015 (std::min, NOMINMAX)
 #include <errno.h>                   // for errno
 #include <sstream>
 #include "base/commandlineflags.h"        // to get the program name

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -1158,6 +1158,10 @@ public:
     base_logging::LogStreamBuf streambuf_;
     int ctr_;  // Counter hack (for the LOG_EVERY_X() macro)
     LogStream *self_;  // Consistency check hack
+
+#if defined(_MSC_VER) && _MSC_VER >= 1900 // needed for msvs 2015 RC
+    LogStream(LogStream&&) = delete;
+#endif
   };
 
 public:

--- a/src/windows/port.cc
+++ b/src/windows/port.cc
@@ -55,6 +55,8 @@ int safe_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
   return _vsnprintf(str, size-1, format, ap);
 }
 
+#if _MSC_VER < 1900  // msvs 2015 finally includes snprintf
+
 int snprintf(char *str, size_t size, const char *format, ...) {
   va_list ap;
   va_start(ap, format);
@@ -62,3 +64,5 @@ int snprintf(char *str, size_t size, const char *format, ...) {
   va_end(ap);
   return r;
 }
+
+#endif


### PR DESCRIPTION
glog won't compile without these changes for msvs 2015 RC. I found the need for deleting the move ctor odd, especially since the libglog_static project compiled without it, only the libglog project needed it (apparently C++11 features cannot be disabled in msvs, see http://stackoverflow.com/questions/23386472/disable-c11-features-in-vs2013)
