### PR TITLE
Fix macro redefinition

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,4 +9,5 @@
 # Please keep the list sorted.
 
 Abhishek Parmar <abhishek@orng.net>
+Brian Silverman <bsilver16384@gmail.com>
 Google Inc.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@
 # Please keep the list sorted.
 
 Abhishek Parmar <abhishek@orng.net>
+Brian Silverman <bsilver16384@gmail.com>
 Fumitoshi Ukai <ukai@google.com>
 Håkan L. S. Younes <hyounes@google.com>
 Ivan Penkov <ivanpe@google.com>

--- a/src/base/mutex.h
+++ b/src/base/mutex.h
@@ -134,7 +134,9 @@
   // *does* cause problems for FreeBSD, or MacOSX, but isn't needed
   // for locking there.)
 # ifdef __linux__
-#   define _XOPEN_SOURCE 500  // may be needed to get the rwlock calls
+#   ifndef _XOPEN_SOURCE  // Some other header might have already set it for us.
+#     define _XOPEN_SOURCE 500  // may be needed to get the rwlock calls
+#   endif
 # endif
 # include <pthread.h>
   typedef pthread_rwlock_t MutexType;


### PR DESCRIPTION
Under Debian Jessie, I get a warning about redefining _XOPEN_SOURCE which is easy to fix.