### PR TITLE
Port glog to Visual Studio 2015 RTM

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1157,6 +1157,12 @@ public:
     int ctr() const { return ctr_; }
     void set_ctr(int ctr) { ctr_ = ctr; }
     LogStream* self() const { return self_; }
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+    // MSC 1900 will implicitly generate this move constructor, which will
+    // in turn (somehow) call the basic_ios copy constructor, which is deleted.
+    // Explicitly deleting this constructor prevents this.
+    LogStream(LogStream &&) = delete;
+#endif
 
     // Legacy std::streambuf methods.
     size_t pcount() const { return streambuf_.pcount(); }

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -1148,6 +1148,12 @@ public:
     int ctr() const { return ctr_; }
     void set_ctr(int ctr) { ctr_ = ctr; }
     LogStream* self() const { return self_; }
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+    // MSC 1900 will implicitly generate this move constructor, which will
+    // in turn (somehow) call the basic_ios copy constructor, which is deleted.
+    // Explicitly deleting this constructor prevents this.
+    LogStream(LogStream &&) = delete;
+#endif
 
     // Legacy std::streambuf methods.
     size_t pcount() const { return streambuf_.pcount(); }

--- a/src/windows/port.cc
+++ b/src/windows/port.cc
@@ -55,6 +55,8 @@ int safe_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
   return _vsnprintf(str, size-1, format, ap);
 }
 
+#if !(defined(_MSC_VER) && (_MSC_VER >= 1900))
+// MSVC 1900 defines this method body as part of stdio.h.
 int snprintf(char *str, size_t size, const char *format, ...) {
   va_list ap;
   va_start(ap, format);
@@ -62,3 +64,4 @@ int snprintf(char *str, size_t size, const char *format, ...) {
   va_end(ap);
   return r;
 }
+#endif


### PR DESCRIPTION
glog v0.3.4 has two outstanding issues with the code that prevent it
from compiling on the RTM of Visual Studio 2015 toolchain (and, more
generally, MSVC).

The first is that the function `snprintf` is defined in the version of
stdio.h that ships with the VS2015 toolchain. The fix for this is
relatively straightforward -- we simply define the function only for
versions before the 2015 version.

The second is that the 2015 toolchain will implicitly define a move
constructor for `LogMessage::LogStream`, which in turn will at some
point call a deleted copy constructor for basic_ios. Our solution in
this commit will be to simply explicitly delete it.
