### PR TITLE
Fix double-free in unit test on Windows.

### DIFF
--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -635,7 +635,8 @@ static void GetFiles(const string& pattern, vector<string>* files) {
   do {
     files->push_back(dirname + data.cFileName);
   } while (FindNextFileA(handle, &data));
-  LOG_SYSRESULT(FindClose(handle));
+  BOOL result = FindClose(handle);
+  LOG_SYSRESULT(result);
 #else
 # error There is no way to do glob.
 #endif


### PR DESCRIPTION
The LOG_SYSRESULT refers to result twice.  Since, in this test,
result expands to FindClose(handle), the handle was being freed twice.

(should have an individual CLA on file)