### PR TITLE
Add signalhandler.cc in the vcproj of libglog static and libglog

### DIFF
--- a/vsprojects/libglog/libglog.vcproj
+++ b/vsprojects/libglog/libglog.vcproj
@@ -192,6 +192,10 @@
 				RelativePath="..\..\src\vlog_is_on.cc"
 				>
 			</File>
+			<File
+				RelativePath="..\..\src\signalhandler.cc"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"

--- a/vsprojects/libglog_static/libglog_static.vcproj
+++ b/vsprojects/libglog_static/libglog_static.vcproj
@@ -165,6 +165,10 @@
 				RelativePath="..\..\src\vlog_is_on.cc"
 				>
 			</File>
+			<File
+				RelativePath="..\..\src\signalhandler.cc"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Header Files"


### PR DESCRIPTION
This source file contains some function, present in headers but could be used because of linking error.
