### PR TITLE
Better support and documentation for CMake projects that consume glog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,44 +551,24 @@ install (TARGETS glog
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib)
 
-# Build tree config
-
-set (glog_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
-set (glog_PACKAGE_DEPS)
-
 if (gflags_FOUND)
-  set (glog_PACKAGE_DEPS
-"
-include (CMakeFindDependencyMacro)
-
-find_dependency (gflags ${gflags_VERSION})
-")
+  set (gflags_DEPENDENCY "find_dependency (gflags ${gflags_VERSION})")
 endif (gflags_FOUND)
 
 configure_package_config_file (glog-config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/glog-config.cmake INSTALL_DESTINATION
-  lib/cmake/glog PATH_VARS glog_INCLUDE_DIR
+  ${CMAKE_CURRENT_BINARY_DIR}/glog-config.cmake
+  INSTALL_DESTINATION lib/cmake/glog
   NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 
-# The version file is the same both for build tree and install mode config
 write_basic_package_version_file (glog-config-version.cmake VERSION
   ${GLOG_VERSION} COMPATIBILITY SameMajorVersion)
 
-# Install config
-
-set (glog_INCLUDE_DIR include)
-
-configure_package_config_file (glog-config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/glog-config.cmake
-  INSTALL_DESTINATION lib/cmake/glog PATH_VARS glog_INCLUDE_DIR
-  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
-
-export (TARGETS glog FILE glog-targets.cmake)
+export (TARGETS glog NAMESPACE glog:: FILE glog-targets.cmake)
 export (PACKAGE glog)
 
 install (FILES
-  ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/glog-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/glog-config.cmake
   ${CMAKE_CURRENT_BINARY_DIR}/glog-config-version.cmake
   DESTINATION lib/cmake/glog)
 
-install (EXPORT glog-targets DESTINATION lib/cmake/glog)
+install (EXPORT glog-targets NAMESPACE glog:: DESTINATION lib/cmake/glog)

--- a/cmake/INSTALL.md
+++ b/cmake/INSTALL.md
@@ -1,0 +1,30 @@
+Building Glog with CMake
+========================
+
+1. Create a build directory and `cd` to it.
+2. Run
+    ```bash
+    cmake path/to/glog
+    ```
+
+3. Afterwards, generated files (GNU make, Visual Studio, etc.) can be used to
+   compile the project.
+
+
+Consuming Glog in a CMake Project
+=================================
+
+To use Glog in your project `myproj`, use:
+
+```cmake
+cmake_minimum_required (VERSION 3.0)
+project (myproj)
+
+find_package (glog 0.3.4 REQUIRED)
+
+add_executable (myapp main.cpp)
+target_link_libraries (myapp glog::glog)
+```
+
+Compile definitions and options will be added automatically to your target as
+needed.

--- a/glog-config.cmake.in
+++ b/glog-config.cmake.in
@@ -1,11 +1,7 @@
 @PACKAGE_INIT@
 
+include (CMakeFindDependencyMacro)
+
+@gflags_DEPENDENCY@
+
 include ("${CMAKE_CURRENT_LIST_DIR}/glog-targets.cmake")
-set_and_check (glog_INCLUDE_DIR "@PACKAGE_glog_INCLUDE_DIR@")
-
-@glog_PACKAGE_DEPS@
-
-set (glog_LIBRARY glog)
-
-set (glog_LIBRARIES ${glog_LIBRARY})
-set (glog_INCLUDE_DIRS ${glog_INCLUDE_DIR})


### PR DESCRIPTION
CMake adds an imported target with the namespaced alias `glog::glog`. Also, added initial CMake usage documentation.