### PR TITLE
Optimize the macro definition "va_copy"

### DIFF
--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -119,7 +119,7 @@ extern int GOOGLE_GLOG_DLL_DECL safe_vsnprintf(char *str, size_t size,
                           const char *format, va_list ap);
 #define vsnprintf(str, size, format, ap)  safe_vsnprintf(str, size, format, ap)
 #ifndef va_copy
-#define va_copy(dst, src)  (dst) = (src)
+#define va_copy(dst, src)  ((void)((dst) = (src)))
 #endif
 
 /* Windows doesn't support specifying the number of buckets as a


### PR DESCRIPTION
There exists "warning C4005: 'va_copy' : macro redefinition" when build glog-0.3.4 with Microsoft Visual Studio 2013. This has been fixed in the latest master branch using "ifndef", but actually "va_copy" is not invoked in any source file, it maybe redundant and can be removed. On the other hand, "va_copy" is not directly supported in versions of Microsoft Visual Studio prior to 2013.

So I think the macro definition "va_copy" is better to stay to be invoked for future use in all versions of Microsoft Visual Studio to keep compatible. At the same time because "va_copy" do not return values according to MSDN (https://msdn.microsoft.com/en-us/library/kb57fad8.aspx), it should be optimized to give useful diagnostics to make the code more robust.