### PR TITLE
Respect configured docdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,7 +40,6 @@ gloginclude_HEADERS = src/glog/log_severity.h
 nodist_gloginclude_HEADERS = src/glog/logging.h src/glog/raw_logging.h src/glog/vlog_is_on.h src/glog/stl_logging.h
 noinst_HEADERS = src/glog/logging.h.in src/glog/raw_logging.h.in src/glog/vlog_is_on.h.in src/glog/stl_logging.h.in
 
-docdir = $(prefix)/share/doc/$(PACKAGE)-$(VERSION)
 ## This is for HTML and other documentation you want to install.
 ## Add your documentation files (in doc/) in addition to these
 ## top-level boilerplate files.  Also add a TODO file if you have one.


### PR DESCRIPTION
Avoid overriding the configured docdir inside the Makefile.
$(datarootdir)/doc/ may differ from $(prefix)/share/doc/
