### PR TITLE
support visual studio 2015

### DIFF
--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -102,6 +102,8 @@ enum { STDIN_FILENO = 0, STDOUT_FILENO = 1, STDERR_FILENO = 2 };
 /* VC11 provides std::hash */
 #if defined(_MSC_VER) && (_MSC_VER < 1700)
 #define hash  hash_compare
+#elif defined(_MSC_VER) && (_MSC_VER>=1900)
+#define HAVE_SNPRINTF
 #endif
 
 /* Sleep is in ms, on windows */


### PR DESCRIPTION
visual studio 2015 had implemented snprintf , so add HAVE_SNPRINTF macro when build by vs2015.
