### PR TITLE
Added $<BUILD_INTERFACE> to gflags include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,7 +390,7 @@ if (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
 endif (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
 
 if (gflags_FOUND)
-  target_include_directories (glog PUBLIC ${gflags_INCLUDE_DIR})
+  target_include_directories (glog PUBLIC $<BUILD_INTERFACE:${gflags_INCLUDE_DIR}>)
   target_link_libraries (glog PUBLIC ${gflags_LIBRARIES})
 
   if (NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
As per CMake [documentation](https://cmake.org/cmake/help/v3.5/command/target_include_directories.html#creating-relocatable-packages) the INSTALL_INTERFACE should not be populated with include directories of transitive dependencies. This makes the installation of glog non-relocatable. This change fixes this.