### PR TITLE
Fix compile error for clang++ on Linux

### DIFF
--- a/src/demangle.h
+++ b/src/demangle.h
@@ -72,6 +72,10 @@
 
 #include "config.h"
 
+#if defined(__linux__)
+  #define GOOGLE_GLOG_DLL_DECL
+#endif
+
 _START_GOOGLE_NAMESPACE_
 
 // Demangle "mangled".  On success, return true and write the

--- a/src/demangle.h
+++ b/src/demangle.h
@@ -72,7 +72,7 @@
 
 #include "config.h"
 
-#if defined(__linux__)
+#if defined(__linux__) && defined(__clang__)
   #define GOOGLE_GLOG_DLL_DECL
 #endif
 


### PR DESCRIPTION
Hi,

I was unable to compile glog using clang++ on Linux due to GOOGLE_GLOG_DLL_DECL being treated as a symbol instead of a macro in demangle.h. This patch fixes the problem as simply as possible, I considered handling it at the configure.ac level, but figured that should be a decision for you guys.

Thanks!
~ ry
