### PR TITLE
Fix autotools build.

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -178,12 +178,3 @@
 
 /* Puts following code inside the Google namespace */
 #undef _START_GOOGLE_NAMESPACE_
-
-// Annoying stuff for windows -- makes sure clients can import these functions
-#ifndef GOOGLE_GLOG_DLL_DECL
-# if defined(_WIN32) && !defined(__CYGWIN__)
-#   define GOOGLE_GLOG_DLL_DECL  __declspec(dllimport)
-# else
-#   define GOOGLE_GLOG_DLL_DECL
-# endif
-#endif

--- a/src/demangle.h
+++ b/src/demangle.h
@@ -71,6 +71,7 @@
 #define BASE_DEMANGLE_H_
 
 #include "config.h"
+#include "glog/logging.h"
 
 _START_GOOGLE_NAMESPACE_
 


### PR DESCRIPTION
It looks like commit 3c49b93 modified the auto-generated file src/config.h.in
to add a definition of macro GOOGLE_GLOG_DLL_DECL. One of the autotools
reverts this change upon running "make", causing the build to fail when a
source file includes demangle.h.

To fix the problem, revert the change to src/config.h.in and include
glog/logging.h from demangle.h which provides a definition of that macro.