### PR TITLE
Set sinks_ to NULL after deletion in LogDestination::DeleteLogDestinations

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -825,6 +825,7 @@ void LogDestination::DeleteLogDestinations() {
   }
   MutexLock l(&sink_mutex_);
   delete sinks_;
+  sinks_ = NULL;
 }
 
 namespace {


### PR DESCRIPTION
`LogDestination::DeleteLogDestinations` deletes `sinks_` but does not set the global to `NULL`. 

Further calls to `LogDestination::AddLogSink` will incorrectly use the stale `sinks_` pointer and potentially crash (https://github.com/google/glog/blob/master/src/logging.cc#L621).

This simple fix sets `sinks_` to `NULL` after the `sinks_` is deleted.