### PR TITLE
cmake: enable position independent code (PIC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,8 @@ add_library (glog
   ${GLOG_SRCS}
 )
 
+set_target_properties (glog PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 if (UNWIND_LIBRARY)
   target_link_libraries (glog PUBLIC ${UNWIND_LIBRARY})
 endif (UNWIND_LIBRARY)


### PR DESCRIPTION
This PR adds the `-fPIC` option to the glog target which fixes linking issues.