### PR TITLE
cmake: fixed clang warning propagation to gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,8 +101,14 @@ check_function_exists (pwrite HAVE_PWRITE)
 check_function_exists (sigaction HAVE_SIGACTION)
 check_function_exists (sigaltstack HAVE_SIGALSTACK)
 
-check_cxx_compiler_flag (-Wno-deprecated HAVE_NO_DEPRECATED)
-check_cxx_compiler_flag (-Wno-unnamed-type-template-args
+# NOTE gcc does not fail if you pass a non-existent -Wno-* option as an
+# argument. However, it will happily fail if you pass the corresponding -W*
+# option. So, we check whether options that disable warnings exist by testing
+# the availability of the corresponding option that enables the warning. This
+# eliminates the need to check for compiler for several (mainly Clang) options.
+
+check_cxx_compiler_flag (-Wdeprecated HAVE_NO_DEPRECATED)
+check_cxx_compiler_flag (-Wunnamed-type-template-args
     HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
 
 # NOTE: Cannot use check_function_exists here since >=vc-14.0 can define
@@ -368,6 +374,8 @@ if (WIN32)
   )
 endif (WIN32)
 
+add_compile_options ($<$<BOOL:${HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS}>:-Wno-unnamed-type-template-args>)
+
 add_library (glog
   ${GLOG_SRCS}
 )
@@ -380,10 +388,6 @@ if (WIN32 AND HAVE_SNPRINTF)
   set_property (SOURCE src/windows/port.cc APPEND PROPERTY COMPILE_DEFINITIONS
     HAVE_SNPRINTF)
 endif (WIN32 AND HAVE_SNPRINTF)
-
-if (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
-  target_compile_options (glog PUBLIC -Wno-unnamed-type-template-args)
-endif (HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
 
 if (gflags_FOUND)
   target_include_directories (glog PUBLIC ${gflags_INCLUDE_DIR})


### PR DESCRIPTION
This PR fixes a warning issued by GCC due to falsely detected options for disabling Clang warnings. Additionally, the disabled option is not propagated to external targets that consume glog.