### PR TITLE
cmake: allow to disable building unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,6 @@ option (WITH_THREADS "Enable multithreading support" ON)
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-include (CMakePackageConfigHelpers)
-include (CPack)
 include (CheckCSourceCompiles)
 include (CheckCXXCompilerFlag)
 include (CheckCXXSourceCompiles)
@@ -43,6 +41,9 @@ include (CheckLibraryExists)
 include (CheckStructHasMember)
 include (CheckSymbolExists)
 include (CheckTypeSize)
+include (CMakePackageConfigHelpers)
+include (CPack)
+include (CTest)
 include (DetermineGflagsNamespace)
 
 set (CMAKE_THREAD_PREFER_PTHREAD 1)
@@ -460,95 +461,97 @@ endif (UNIX OR (APPLE AND HAVE_DLADDR))
 
 # Unit testing
 
-add_executable (logging_unittest
-  src/logging_unittest.cc
-)
-
-target_link_libraries (logging_unittest PRIVATE glog)
-
-add_executable (stl_logging_unittest
-  src/stl_logging_unittest.cc
-)
-
-target_link_libraries (stl_logging_unittest PRIVATE glog)
-
-if (HAVE_NO_DEPRECATED)
-  set_property (TARGET stl_logging_unittest APPEND PROPERTY COMPILE_OPTIONS
-    -Wno-deprecated)
-endif (HAVE_NO_DEPRECATED)
-
-if (HAVE_UNORDERED_MAP AND HAVE_UNORDERED_SET)
-  target_compile_definitions (stl_logging_unittest PRIVATE
-    GLOG_STL_LOGGING_FOR_UNORDERED)
-endif (HAVE_UNORDERED_MAP AND HAVE_UNORDERED_SET)
-
-if (HAVE_TR1_UNORDERED_MAP AND HAVE_TR1_UNORDERED_SET)
-  target_compile_definitions (stl_logging_unittest PRIVATE
-    GLOG_STL_LOGGING_FOR_TR1_UNORDERED)
-endif (HAVE_TR1_UNORDERED_MAP AND HAVE_TR1_UNORDERED_SET)
-
-if (HAVE_EXT_HASH_MAP AND HAVE_EXT_HASH_SET)
-  target_compile_definitions (stl_logging_unittest PRIVATE
-    GLOG_STL_LOGGING_FOR_EXT_HASH)
-endif (HAVE_EXT_HASH_MAP AND HAVE_EXT_HASH_SET)
-
-if (HAVE_EXT_SLIST)
-  target_compile_definitions (stl_logging_unittest PRIVATE
-    GLOG_STL_LOGGING_FOR_EXT_SLIST)
-endif (HAVE_EXT_SLIST)
-
-if (HAVE_SYMBOLIZE)
-  add_executable (symbolize_unittest
-    src/symbolize_unittest.cc
+if (BUILD_TESTING)
+  add_executable (logging_unittest
+    src/logging_unittest.cc
   )
 
-  target_link_libraries (symbolize_unittest PRIVATE glog)
-endif (HAVE_SYMBOLIZE)
+  target_link_libraries (logging_unittest PRIVATE glog)
 
-add_executable (demangle_unittest
-  src/demangle_unittest.cc
-)
-
-target_link_libraries (demangle_unittest PRIVATE glog)
-
-if (HAVE_STACKTRACE)
-  add_executable (stacktrace_unittest
-    src/stacktrace_unittest.cc
+  add_executable (stl_logging_unittest
+    src/stl_logging_unittest.cc
   )
 
-  target_link_libraries (stacktrace_unittest PRIVATE glog)
-endif (HAVE_STACKTRACE)
+  target_link_libraries (stl_logging_unittest PRIVATE glog)
 
-add_executable (utilities_unittest
-  src/utilities_unittest.cc
-)
+  if (HAVE_NO_DEPRECATED)
+    set_property (TARGET stl_logging_unittest APPEND PROPERTY COMPILE_OPTIONS
+      -Wno-deprecated)
+  endif (HAVE_NO_DEPRECATED)
 
-target_link_libraries (utilities_unittest PRIVATE glog)
+  if (HAVE_UNORDERED_MAP AND HAVE_UNORDERED_SET)
+    target_compile_definitions (stl_logging_unittest PRIVATE
+      GLOG_STL_LOGGING_FOR_UNORDERED)
+  endif (HAVE_UNORDERED_MAP AND HAVE_UNORDERED_SET)
 
-if (HAVE_STACKTRACE AND HAVE_SYMBOLIZE)
-  add_executable (signalhandler_unittest
-    src/signalhandler_unittest.cc
+  if (HAVE_TR1_UNORDERED_MAP AND HAVE_TR1_UNORDERED_SET)
+    target_compile_definitions (stl_logging_unittest PRIVATE
+      GLOG_STL_LOGGING_FOR_TR1_UNORDERED)
+  endif (HAVE_TR1_UNORDERED_MAP AND HAVE_TR1_UNORDERED_SET)
+
+  if (HAVE_EXT_HASH_MAP AND HAVE_EXT_HASH_SET)
+    target_compile_definitions (stl_logging_unittest PRIVATE
+      GLOG_STL_LOGGING_FOR_EXT_HASH)
+  endif (HAVE_EXT_HASH_MAP AND HAVE_EXT_HASH_SET)
+
+  if (HAVE_EXT_SLIST)
+    target_compile_definitions (stl_logging_unittest PRIVATE
+      GLOG_STL_LOGGING_FOR_EXT_SLIST)
+  endif (HAVE_EXT_SLIST)
+
+  if (HAVE_SYMBOLIZE)
+    add_executable (symbolize_unittest
+      src/symbolize_unittest.cc
+    )
+
+    target_link_libraries (symbolize_unittest PRIVATE glog)
+  endif (HAVE_SYMBOLIZE)
+
+  add_executable (demangle_unittest
+    src/demangle_unittest.cc
   )
 
-  target_link_libraries (signalhandler_unittest PRIVATE glog)
-endif (HAVE_STACKTRACE AND HAVE_SYMBOLIZE)
+  target_link_libraries (demangle_unittest PRIVATE glog)
 
-add_test (NAME demangle COMMAND demangle_unittest)
-add_test (NAME logging COMMAND logging_unittest)
+  if (HAVE_STACKTRACE)
+    add_executable (stacktrace_unittest
+      src/stacktrace_unittest.cc
+    )
 
-if (TARGET signalhandler_unittest)
-  add_test (NAME signalhandler COMMAND signalhandler_unittest)
-endif (TARGET signalhandler_unittest)
+    target_link_libraries (stacktrace_unittest PRIVATE glog)
+  endif (HAVE_STACKTRACE)
 
-if (TARGET stacktrace_unittest)
-  add_test (NAME stacktrace COMMAND stacktrace_unittest)
-endif (TARGET stacktrace_unittest)
+  add_executable (utilities_unittest
+    src/utilities_unittest.cc
+  )
 
-add_test (NAME stl_logging COMMAND stl_logging_unittest)
+  target_link_libraries (utilities_unittest PRIVATE glog)
 
-if (TARGET symbolize_unittest)
-  add_test (NAME symbolize COMMAND symbolize_unittest)
-endif (TARGET symbolize_unittest)
+  if (HAVE_STACKTRACE AND HAVE_SYMBOLIZE)
+    add_executable (signalhandler_unittest
+      src/signalhandler_unittest.cc
+    )
+
+    target_link_libraries (signalhandler_unittest PRIVATE glog)
+  endif (HAVE_STACKTRACE AND HAVE_SYMBOLIZE)
+
+  add_test (NAME demangle COMMAND demangle_unittest)
+  add_test (NAME logging COMMAND logging_unittest)
+
+  if (TARGET signalhandler_unittest)
+    add_test (NAME signalhandler COMMAND signalhandler_unittest)
+  endif (TARGET signalhandler_unittest)
+
+  if (TARGET stacktrace_unittest)
+    add_test (NAME stacktrace COMMAND stacktrace_unittest)
+  endif (TARGET stacktrace_unittest)
+
+  add_test (NAME stl_logging COMMAND stl_logging_unittest)
+
+  if (TARGET symbolize_unittest)
+    add_test (NAME symbolize COMMAND symbolize_unittest)
+  endif (TARGET symbolize_unittest)
+endif (BUILD_TESTING)
 
 install (TARGETS glog
   EXPORT glog-targets


### PR DESCRIPTION
This commit introduces a CMake `BUILD_TESTING` boolean option that allows to disable unit tests. This is especially useful in superbuilds where typically only the main library is built. By default, this option is enabled.