### PR TITLE
support ISO-8601 timestamp format

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -339,6 +339,9 @@ DECLARE_bool(alsologtostderr);
 // Set color messages logged to stderr (if supported by terminal).
 DECLARE_bool(colorlogtostderr);
 
+// Format messages' timestamp using ISO 8601 standard
+DECLARE_bool(iso8601format);
+
 // Log messages at a level >= this flag are automatically sent to
 // stderr in addition to log files.
 DECLARE_int32(stderrthreshold);


### PR DESCRIPTION
Some monitor system don't recognize glog's timestamp format. And currently glog don't print year. This MR add support for ISO-8601 timestamp format, and add an option: `FLAGS_iso8601format = 1;` which is default set to `false`.