### PR TITLE
Port stack tracing to Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,11 @@ if (HAVE_EXECINFO_H)
   set (HAVE_STACKTRACE 1)
 endif (HAVE_EXECINFO_H)
 
+if (WIN32)
+  set (HAVE_STACKTRACE 1)
+  target_link_libraries (glog PUBLIC Dbghelp.lib)
+endif (WIN32)
+
 if (UNIX OR (APPLE AND HAVE_DLADDR))
   set (HAVE_SYMBOLIZE 1)
 endif (UNIX OR (APPLE AND HAVE_DLADDR))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,7 @@ endif (HAVE_EXECINFO_H)
 
 if (WIN32)
   set (HAVE_STACKTRACE 1)
+  set (HAVE_SYMBOLIZE 1)
   target_link_libraries (glog PUBLIC Dbghelp.lib)
 endif (WIN32)
 
@@ -532,13 +533,13 @@ if (BUILD_TESTING)
 
   target_link_libraries (utilities_unittest PRIVATE glog)
 
-  if (HAVE_STACKTRACE AND HAVE_SYMBOLIZE)
+  if (HAVE_STACKTRACE AND HAVE_SYMBOLIZE AND NOT WIN32)
     add_executable (signalhandler_unittest
       src/signalhandler_unittest.cc
     )
 
     target_link_libraries (signalhandler_unittest PRIVATE glog)
-  endif (HAVE_STACKTRACE AND HAVE_SYMBOLIZE)
+  endif (HAVE_STACKTRACE AND HAVE_SYMBOLIZE AND NOT WIN32)
 
   add_test (NAME demangle COMMAND demangle_unittest)
   add_test (NAME logging COMMAND logging_unittest)

--- a/src/stacktrace_windows-inl.h
+++ b/src/stacktrace_windows-inl.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2000 - 2007, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Portable implementation - just use glibc
+//
+// Note:  The glibc implementation may cause a call to malloc.
+// This can cause a deadlock in HeapProfiler.
+#include <execinfo.h>
+#include <string.h>
+#include "stacktrace.h"
+
+_START_GOOGLE_NAMESPACE_
+
+// If you change this function, also change GetStackFrames below.
+int GetStackTrace(void** result, int max_depth, int skip_count) {
+  static const int kStackLength = 64;
+  void * stack[kStackLength];
+  int size;
+
+  size = backtrace(stack, kStackLength);
+  skip_count++;  // we want to skip the current frame as well
+  int result_count = size - skip_count;
+  if (result_count < 0)
+    result_count = 0;
+  if (result_count > max_depth)
+    result_count = max_depth;
+  for (int i = 0; i < result_count; i++)
+    result[i] = stack[i + skip_count];
+
+  return result_count;
+}
+
+_END_GOOGLE_NAMESPACE_

--- a/src/stacktrace_windows-inl.h
+++ b/src/stacktrace_windows-inl.h
@@ -34,57 +34,17 @@
 #include "port.h"
 #include "stacktrace.h"
 #include "Dbghelp.h"
-#include <vector>
-
-#include <iostream>
 
 _START_GOOGLE_NAMESPACE_
 
-static bool ready_to_run = false;
-class StackTraceInit {
-public:
-  HANDLE hProcess;
-  StackTraceInit() {
-    // Initialize the symbol handler
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680344(v=vs.85).aspx
-    hProcess = GetCurrentProcess();
-    SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
-    SymInitialize(hProcess, NULL, true);
-    ready_to_run = true;
-  }
-  ~StackTraceInit() {
-    SymCleanup(hProcess);
-    ready_to_run = false;
-  }
-};
-
-static const StackTraceInit module_initializer;  // Force initialization
-
 // If you change this function, also change GetStackFrames below.
 int GetStackTrace(void** result, int max_depth, int skip_count) {
-  if (!ready_to_run) {
-    return 0;
-  }
-  skip_count++;  // we want to skip the current frame as well
   if (max_depth > 64) {
     max_depth = 64;
   }
-  std::vector<void*> stack(max_depth);
+  skip_count++;  // we want to skip the current frame as well
   // This API is thread-safe (moreover it walks only the current thread).
-  int size = CaptureStackBackTrace(skip_count, max_depth, &stack[0], NULL);
-  for (int i = 0; i < size; ++i) {
-    // Resolve symbol information from address.
-    char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
-    SYMBOL_INFO* symbol = reinterpret_cast<SYMBOL_INFO*>(buffer);
-    symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
-    symbol->MaxNameLen = MAX_SYM_NAME;
-    SymFromAddr(module_initializer.hProcess, reinterpret_cast<DWORD64>(stack[i]), 0, symbol);
-    // This is proof-of-concept.
-    std::cout << i << ": " << symbol->Name << "@" << symbol->Address << std::endl;
-    result[i] = stack[i];
-  }
-
-  return size;
+  return CaptureStackBackTrace(skip_count, max_depth, result, NULL);
 }
 
 _END_GOOGLE_NAMESPACE_

--- a/src/stacktrace_windows-inl.h
+++ b/src/stacktrace_windows-inl.h
@@ -27,33 +27,64 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Portable implementation - just use glibc
+// Author: Andrew Schwartzmeyer
 //
-// Note:  The glibc implementation may cause a call to malloc.
-// This can cause a deadlock in HeapProfiler.
-#include <execinfo.h>
-#include <string.h>
+// Windows implementation - just use CaptureStackBackTrace
+
+#include "port.h"
 #include "stacktrace.h"
+#include "Dbghelp.h"
+#include <vector>
+
+#include <iostream>
 
 _START_GOOGLE_NAMESPACE_
 
+static bool ready_to_run = false;
+class StackTraceInit {
+public:
+  HANDLE hProcess;
+  StackTraceInit() {
+    // Initialize the symbol handler
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680344(v=vs.85).aspx
+    hProcess = GetCurrentProcess();
+    SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
+    SymInitialize(hProcess, NULL, true);
+    ready_to_run = true;
+  }
+  ~StackTraceInit() {
+    SymCleanup(hProcess);
+    ready_to_run = false;
+  }
+};
+
+static const StackTraceInit module_initializer;  // Force initialization
+
 // If you change this function, also change GetStackFrames below.
 int GetStackTrace(void** result, int max_depth, int skip_count) {
-  static const int kStackLength = 64;
-  void * stack[kStackLength];
-  int size;
-
-  size = backtrace(stack, kStackLength);
+  if (!ready_to_run) {
+    return 0;
+  }
   skip_count++;  // we want to skip the current frame as well
-  int result_count = size - skip_count;
-  if (result_count < 0)
-    result_count = 0;
-  if (result_count > max_depth)
-    result_count = max_depth;
-  for (int i = 0; i < result_count; i++)
-    result[i] = stack[i + skip_count];
+  if (max_depth > 64) {
+    max_depth = 64;
+  }
+  std::vector<void*> stack(max_depth);
+  // This API is thread-safe (moreover it walks only the current thread).
+  int size = CaptureStackBackTrace(skip_count, max_depth, &stack[0], NULL);
+  for (int i = 0; i < size; ++i) {
+    // Resolve symbol information from address.
+    char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
+    SYMBOL_INFO* symbol = reinterpret_cast<SYMBOL_INFO*>(buffer);
+    symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+    symbol->MaxNameLen = MAX_SYM_NAME;
+    SymFromAddr(module_initializer.hProcess, reinterpret_cast<DWORD64>(stack[i]), 0, symbol);
+    // This is proof-of-concept.
+    std::cout << i << ": " << symbol->Name << "@" << symbol->Address << std::endl;
+    result[i] = stack[i];
+  }
 
-  return result_count;
+  return size;
 }
 
 _END_GOOGLE_NAMESPACE_

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -49,9 +49,21 @@ using namespace GFLAGS_NAMESPACE;
 using namespace std;
 using namespace GOOGLE_NAMESPACE;
 
-#if defined(HAVE_STACKTRACE) && defined(__ELF__)
+#if defined(HAVE_STACKTRACE)
 
 #define always_inline
+
+// A wrapper function for Symbolize() to make the unit test simple.
+static const char *TrySymbolize(void *pc) {
+  static char symbol[4096];
+  if (Symbolize(pc, symbol, sizeof(symbol))) {
+    return symbol;
+  } else {
+    return NULL;
+  }
+}
+
+# if defined(__ELF__)
 
 // This unit tests make sense only with GCC.
 // Uses lots of GCC specific features.
@@ -69,16 +81,6 @@ using namespace GOOGLE_NAMESPACE;
 #    define TEST_X86_32_AND_64 1
 #  endif  // defined(__i386__) || defined(__x86_64__)
 #endif
-
-// A wrapper function for Symbolize() to make the unit test simple.
-static const char *TrySymbolize(void *pc) {
-  static char symbol[4096];
-  if (Symbolize(pc, symbol, sizeof(symbol))) {
-    return symbol;
-  } else {
-    return NULL;
-  }
-}
 
 // Make them C linkage to avoid mangled names.
 extern "C" {
@@ -340,11 +342,42 @@ void ATTRIBUTE_NOINLINE TestWithReturnAddress() {
 #endif
 }
 
+# elif defined(OS_WINDOWS)
+
+#include <intrin.h>
+#pragma intrinsic(_ReturnAddress)
+
+struct Foo {
+  static void func(int x);
+};
+
+__declspec(noinline) void Foo::func(int x) {
+  volatile int a = x;
+  ++a;
+}
+
+TEST(Symbolize, SymbolizeWithDemangling) {
+  Foo::func(100);
+  const char* ret = TrySymbolize((void *)(&Foo::func));
+  EXPECT_STREQ("public: static void __cdecl Foo::func(int)", ret);
+}
+
+__declspec(noinline) void TestWithReturnAddress() {
+  void *return_address = _ReturnAddress();
+  const char *symbol = TrySymbolize(return_address);
+  CHECK(symbol != NULL);
+  CHECK_STREQ(symbol, "main");
+  cout << "Test case TestWithReturnAddress passed." << endl;
+}
+# endif  // __ELF__
+#endif  // HAVE_STACKTRACE
+
 int main(int argc, char **argv) {
   FLAGS_logtostderr = true;
   InitGoogleLogging(argv[0]);
   InitGoogleTest(&argc, argv);
-#ifdef HAVE_SYMBOLIZE
+#if defined(HAVE_SYMBOLIZE)
+# if defined(__ELF__)
   // We don't want to get affected by the callback interface, that may be
   // used to install some callback function at InitGoogle() time.
   InstallSymbolizeCallback(NULL);
@@ -353,18 +386,15 @@ int main(int argc, char **argv) {
   TestWithPCInsideNonInlineFunction();
   TestWithReturnAddress();
   return RUN_ALL_TESTS();
-#else
-  return 0;
-#endif
-}
-
-#else
-int main() {
-#ifdef HAVE_SYMBOLIZE
+# elif defined(OS_WINDOWS)
+  TestWithReturnAddress();
+  return RUN_ALL_TESTS();
+# else
   printf("PASS (no symbolize_unittest support)\n");
+  return 0;
+# endif  // __ELF__
 #else
   printf("PASS (no symbolize support)\n");
-#endif
   return 0;
+#endif
 }
-#endif  // HAVE_STACKTRACE

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -131,6 +131,9 @@
 #elif defined(OS_MACOSX) && defined(HAVE_DLADDR)
 // Use dladdr to symbolize.
 # define HAVE_SYMBOLIZE
+#elif defined(OS_WINDOWS)
+// Use Dbghelp.dll to symbolize
+# define HAVE_SYMBOLIZE
 #endif
 
 #ifndef ARRAYSIZE

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -97,6 +97,8 @@
 //    malloc() from the unwinder.  This is a problem because we're
 //    trying to use the unwinder to instrument malloc().
 //
+// 4) The Windows API CaptureStackTrace.
+//
 // Note: if you add a new implementation here, make sure it works
 // correctly when GetStackTrace() is called with max_depth == 0.
 // Some code may do that.
@@ -110,6 +112,8 @@
 #  define STACKTRACE_H "stacktrace_x86_64-inl.h"
 # elif (defined(__ppc__) || defined(__PPC__)) && __GNUC__ >= 2
 #  define STACKTRACE_H "stacktrace_powerpc-inl.h"
+# elif defined(OS_WINDOWS)
+#  define STACKTRACE_H "stacktrace_windows-inl.h"
 # endif
 #endif
 


### PR DESCRIPTION
This set of patches implements the stack trace, symbolizer, and demangler for Windows, and their unit tests. It utilizes the Windows debugging APIs in `"Dbghelp.h"`. I'd like this to start being reviewed, but feel it probably needs some more unit tests and definitely needs to be integration tested. I'll also clean up the commits before it's applied. This _is_ a work in progress, with more up-to-date work on my [test branch](https://github.com/andschwa/glog/tree/test). I mostly need to fix how the stack trace reporting is called, as using the signal handler does not seem to result in the desired behavior on Windows.

/cc @hausdorff