### PR TITLE
cmake: changed project name from google-glog to glog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if (POLICY CMP0063)
   cmake_policy (SET CMP0063 NEW)
 endif (POLICY CMP0063)
 
-project (google-glog)
+project (glog)
 
 enable_testing ()
 


### PR DESCRIPTION
This fixes the default install location on Windows. Specifically, find_package works now out-of-the box with the default CMAKE_INSTALL_PREFIX.