### PR TITLE
Fix vmodule bugs

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -915,14 +915,24 @@ PLOG_IF(FATAL, GOOGLE_PREDICT_BRANCH_NOT_TAKEN((invocation) == -1))    \
         &what_to_do).stream()
 
 namespace glog_internal_namespace_ {
+
+#if __cplusplus >= 201103L
+
+#define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) static_assert(expr, #msg)
+
+#else
+
 template <bool>
 struct CompileAssert {
 };
-struct CrashReason;
-}  // namespace glog_internal_namespace_
 
 #define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
   typedef @ac_google_namespace@::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+
+#endif
+
+struct CrashReason;
+}  // namespace glog_internal_namespace_
 
 #define LOG_EVERY_N(severity, n)                                        \
   GOOGLE_GLOG_COMPILE_ASSERT(@ac_google_namespace@::GLOG_ ## severity < \

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -162,7 +162,7 @@ int SetVLOGLevel(const char* module_pattern, int log_level) {
   int result = FLAGS_v;
   int const pattern_len = strlen(module_pattern);
   bool found = false;
-  MutexLock l(&vmodule_lock);  // protect whole read-modify-write
+  vmodule_lock.Lock();  // protect whole read-modify-write
   for (const VModuleInfo* info = vmodule_list;
        info != NULL; info = info->next) {
     if (info->module_pattern == module_pattern) {
@@ -186,6 +186,7 @@ int SetVLOGLevel(const char* module_pattern, int log_level) {
     info->next = vmodule_list;
     vmodule_list = info;
   }
+  vmodule_lock.Unlock();
   RAW_VLOG(1, "Set VLOG level for \"%s\" to %d", module_pattern, log_level);
   return result;
 }


### PR DESCRIPTION
1. Define GOOGLE_GLOG_COMPILE_ASSERT macro for c++ 11 to compile without warnings
2. Fix vmodule_lock deadlock bug when changing settings during run-time.
3. Reset cached values for site flags when vmodule level is changed during runtime.