### PR TITLE
Avoid creating large amounts of `-WUnused` in projects using glog

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -934,8 +934,13 @@ struct CrashReason;
 bool IsFailureSignalHandlerInstalled();
 }  // namespace glog_internal_namespace_
 
-#define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
-  typedef @ac_google_namespace@::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+// If static_assert is available (C++11), make use of it.
+#if __cplusplus <= 199711L
+    #define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
+      typedef @ac_google_namespace@::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+#else
+    #define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) static_assert(expr, #msg)
+#endif
 
 #define LOG_EVERY_N(severity, n)                                        \
   GOOGLE_GLOG_COMPILE_ASSERT(@ac_google_namespace@::GLOG_ ## severity < \

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -938,8 +938,12 @@ struct CrashReason;
 bool IsFailureSignalHandlerInstalled();
 }  // namespace glog_internal_namespace_
 
-#define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
-  typedef google::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+#if __cplusplus <= 199711L
+    #define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
+      typedef google::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
+#else
+    #define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) static_assert(expr, #msg)
+#endif
 
 #define LOG_EVERY_N(severity, n)                                        \
   GOOGLE_GLOG_COMPILE_ASSERT(google::GLOG_ ## severity < \


### PR DESCRIPTION
`logging.h` contains a fancy macro that emulates `static_assert` via an interesting use of `typedef`. In situations where the assertion is true, the typedef ends up unused, which yields a warning on some recent compilers.

This PR redefines the macro to use the C++ built-in `static_assert` when compiling for C++11 or newer (since that is when the built-in was added). This avoids the warnings, and provides slightly nicer errors when the assert fails.

This seems a more elegant solution to the problem than attempting to directly suppress the warning, since there seems to be no non-insane way to do that in a compiler-agnostic way.

