### PR TITLE
Port stack tracing to Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,6 +10,7 @@
 
 Abhishek Dasgupta <abhi2743@gmail.com>
 Abhishek Parmar <abhishek@orng.net>
+Andrew Schwartzmeyer <andrew@schwartzmeyer.com>
 Andy Ying <andy@trailofbits.com>
 Brian Silverman <bsilver16384@gmail.com>
 Google Inc.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,11 @@ if (HAVE_EXECINFO_H)
   set (HAVE_STACKTRACE 1)
 endif (HAVE_EXECINFO_H)
 
+if (WIN32)
+  set (HAVE_STACKTRACE 1)
+  target_link_libraries (glog PUBLIC Dbghelp.lib)
+endif (WIN32)
+
 if (UNIX OR (APPLE AND HAVE_DLADDR))
   set (HAVE_SYMBOLIZE 1)
 endif (UNIX OR (APPLE AND HAVE_DLADDR))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,9 +364,9 @@ set (GLOG_SRCS
   src/vlog_is_on.cc
 )
 
-if (HAVE_PTHREAD)
+if (HAVE_PTHREAD OR WIN32)
   list (APPEND GLOG_SRCS src/signalhandler.cc)
-endif (HAVE_PTHREAD)
+endif (HAVE_PTHREAD OR WIN32)
 
 if (WIN32)
   list (APPEND GLOG_SRCS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,7 @@ endif (HAVE_EXECINFO_H)
 
 if (WIN32)
   set (HAVE_STACKTRACE 1)
+  set (HAVE_SYMBOLIZE 1)
   target_link_libraries (glog PUBLIC Dbghelp.lib)
 endif (WIN32)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,7 +458,6 @@ endif (HAVE_EXECINFO_H)
 if (WIN32)
   set (HAVE_STACKTRACE 1)
   set (HAVE_SYMBOLIZE 1)
-  target_link_libraries (glog PUBLIC Dbghelp.lib)
 endif (WIN32)
 
 if (UNIX OR (APPLE AND HAVE_DLADDR))

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 
 Abhishek Dasgupta <abhi2743@gmail.com>
 Abhishek Parmar <abhishek@orng.net>
+Andrew Schwartzmeyer <andrew@schwartzmeyer.com>
 Andy Ying <andy@trailofbits.com>
 Brian Silverman <bsilver16384@gmail.com>
 Fumitoshi Ukai <ukai@google.com>

--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -35,10 +35,16 @@
 // Note that we only have partial C++0x support yet.
 
 #include <stdio.h>  // for NULL
+#include "utilities.h"
 #include "demangle.h"
+
+#if defined(OS_WINDOWS)
+#include <DbgHelp.h>
+#endif
 
 _START_GOOGLE_NAMESPACE_
 
+#if !defined(OS_WINDOWS)
 typedef struct {
   const char *abbrev;
   const char *real_name;
@@ -1293,12 +1299,37 @@ static bool ParseTopLevelMangledName(State *state) {
   }
   return false;
 }
+#endif
 
 // The demangler entry point.
 bool Demangle(const char *mangled, char *out, int out_size) {
+#if defined(OS_WINDOWS)
+  // When built with incremental linking, the Windows debugger
+  // library provides a more complicated `Symbol->Name` with the
+  // Incremental Linking Table offset, which looks like
+  // `@ILT+1105(?func@Foo@@SAXH@Z)`. However, the demangler expects
+  // only the mangled symbol, `?func@Foo@@SAXH@Z`. Fortunately, the
+  // mangled symbol is guaranteed not to have parentheses,
+  // so we search for `(` and extract up to `)`.
+  //
+  // Since we may be in a signal handler here, we cannot use `std::string`.
+  char buffer[1024];  // Big enough for a sane symbol.
+  const char *lparen = strchr(mangled, '(');
+  if (lparen) {
+    // Extract the string `(?...)`
+    const char *rparen = strchr(lparen, ')');
+    size_t length = rparen - lparen - 1;
+    strncpy(buffer, lparen + 1, length);
+    buffer[length] = '\0';
+    mangled = buffer;
+  } // Else the symbol wasn't inside a set of parentheses
+  // We use the ANSI version to ensure the string type is always `char *`.
+  return UnDecorateSymbolName(mangled, out, out_size, UNDNAME_COMPLETE);
+#else
   State state;
   InitState(&state, mangled, out, out_size);
   return ParseTopLevelMangledName(&state) && !state.overflowed;
+#endif
 }
 
 _END_GOOGLE_NAMESPACE_

--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -40,6 +40,7 @@
 
 #if defined(OS_WINDOWS)
 #include <DbgHelp.h>
+#pragma comment(lib, "DbgHelp")
 #endif
 
 _START_GOOGLE_NAMESPACE_

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1463,16 +1463,13 @@ void LogMessage::RecordCrashReason(
 # define ATTRIBUTE_NORETURN
 #endif
 
+#if defined(OS_WINDOWS)
+__declspec(noreturn)
+#endif
 static void logging_fail() ATTRIBUTE_NORETURN;
 
 static void logging_fail() {
-#if defined(_DEBUG) && defined(_MSC_VER)
-  // When debugging on windows, avoid the obnoxious dialog and make
-  // it possible to continue past a LOG(FATAL) in the debugger
-  __debugbreak();
-#else
   abort();
-#endif
 }
 
 typedef void (*logging_fail_func_t)() ATTRIBUTE_NORETURN;

--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -48,9 +48,6 @@
 
 _START_GOOGLE_NAMESPACE_
 
-// TOOD(hamaji): Use signal instead of sigaction?
-#ifdef HAVE_SIGACTION
-
 namespace {
 
 // We'll install the failure signal handler for these signals.  We could
@@ -66,9 +63,13 @@ const struct {
   { SIGILL, "SIGILL" },
   { SIGFPE, "SIGFPE" },
   { SIGABRT, "SIGABRT" },
+#if !defined(OS_WINDOWS)
   { SIGBUS, "SIGBUS" },
+#endif
   { SIGTERM, "SIGTERM" },
 };
+
+static bool kFailureSignalHandlerInstalled = false;
 
 // Returns the program counter from signal context, NULL if unknown.
 void* GetPC(void* ucontext_in_void) {
@@ -168,6 +169,9 @@ void DumpTimeInfo() {
   g_failure_writer(buf, formatter.num_bytes_written());
 }
 
+// TOOD(hamaji): Use signal instead of sigaction?
+#ifdef HAVE_SIGACTION
+
 // Dumps information about the signal to STDERR.
 void DumpSignalInfo(int signal_number, siginfo_t *siginfo) {
   // Get the signal name.
@@ -213,6 +217,8 @@ void DumpSignalInfo(int signal_number, siginfo_t *siginfo) {
   g_failure_writer(buf, formatter.num_bytes_written());
 }
 
+#endif  // HAVE_SIGACTION
+
 // Dumps information about the stack frame to STDERR.
 void DumpStackFrameInfo(const char* prefix, void* pc) {
   // Get the symbol name.
@@ -240,12 +246,17 @@ void DumpStackFrameInfo(const char* prefix, void* pc) {
 
 // Invoke the default signal handler.
 void InvokeDefaultSignalHandler(int signal_number) {
+#ifdef HAVE_SIGACTION
   struct sigaction sig_action;
   memset(&sig_action, 0, sizeof(sig_action));
   sigemptyset(&sig_action.sa_mask);
   sig_action.sa_handler = SIG_DFL;
   sigaction(signal_number, &sig_action, NULL);
   kill(getpid(), signal_number);
+#elif defined(OS_WINDOWS)
+  signal(signal_number, SIG_DFL);
+  raise(signal_number);
+#endif
 }
 
 // This variable is used for protecting FailureSignalHandler() from
@@ -256,9 +267,14 @@ static pthread_t* g_entered_thread_id_pointer = NULL;
 
 // Dumps signal and stack frame information, and invokes the default
 // signal handler once our job is done.
+#if defined(OS_WINDOWS)
+void FailureSignalHandler(int signal_number)
+#else
 void FailureSignalHandler(int signal_number,
                           siginfo_t *signal_info,
-                          void *ucontext) {
+                          void *ucontext)
+#endif
+{
   // First check if we've already entered the function.  We use an atomic
   // compare and swap operation for platforms that support it.  For other
   // platforms, we use a naive method that could lead to a subtle race.
@@ -298,16 +314,20 @@ void FailureSignalHandler(int signal_number,
   // First dump time info.
   DumpTimeInfo();
 
+#if !defined(OS_WINDOWS)
   // Get the program counter from ucontext.
   void *pc = GetPC(ucontext);
   DumpStackFrameInfo("PC: ", pc);
+#endif
 
 #ifdef HAVE_STACKTRACE
   // Get the stack traces.
   void *stack[32];
   // +1 to exclude this function.
   const int depth = GetStackTrace(stack, ARRAYSIZE(stack), 1);
+# ifdef HAVE_SIGACTION
   DumpSignalInfo(signal_number, signal_info);
+# endif
   // Dump the stack traces.
   for (int i = 0; i < depth; ++i) {
     DumpStackFrameInfo("    ", stack[i]);
@@ -333,18 +353,19 @@ void FailureSignalHandler(int signal_number,
 
 }  // namespace
 
-#endif  // HAVE_SIGACTION
-
 namespace glog_internal_namespace_ {
 
 bool IsFailureSignalHandlerInstalled() {
 #ifdef HAVE_SIGACTION
+  // TODO(andschwa): Return kFailureSignalHandlerInstalled?
   struct sigaction sig_action;
   memset(&sig_action, 0, sizeof(sig_action));
   sigemptyset(&sig_action.sa_mask);
   sigaction(SIGABRT, NULL, &sig_action);
   if (sig_action.sa_sigaction == &FailureSignalHandler)
     return true;
+#elif defined(OS_WINDOWS)
+  return kFailureSignalHandlerInstalled;
 #endif  // HAVE_SIGACTION
   return false;
 }
@@ -363,11 +384,18 @@ void InstallFailureSignalHandler() {
   for (size_t i = 0; i < ARRAYSIZE(kFailureSignals); ++i) {
     CHECK_ERR(sigaction(kFailureSignals[i].number, &sig_action, NULL));
   }
+  kFailureSignalHandlerInstalled = true;
+#elif defined(OS_WINDOWS)
+  for (size_t i = 0; i < ARRAYSIZE(kFailureSignals); ++i) {
+    CHECK_NE(signal(kFailureSignals[i].number, &FailureSignalHandler),
+             SIG_ERR);
+  }
+  kFailureSignalHandlerInstalled = true;
 #endif  // HAVE_SIGACTION
 }
 
 void InstallFailureWriter(void (*writer)(const char* data, int size)) {
-#ifdef HAVE_SIGACTION
+#if defined(HAVE_SIGACTION) || defined(OS_WINDOWS)
   g_failure_writer = writer;
 #endif  // HAVE_SIGACTION
 }

--- a/src/signalhandler_unittest.cc
+++ b/src/signalhandler_unittest.cc
@@ -34,7 +34,9 @@
 
 #include "utilities.h"
 
-#include <pthread.h>
+#if defined(HAVE_PTHREAD)
+# include <pthread.h>
+#endif
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -87,12 +89,20 @@ int main(int argc, char **argv) {
     fprintf(stderr, "looping\n");
     while (true);
   } else if (command == "die_in_thread") {
+#if defined(HAVE_PTHREAD)
     pthread_t thread;
     pthread_create(&thread, NULL, &DieInThread, NULL);
     pthread_join(thread, NULL);
+#else
+    fprintf(stderr, "no pthread\n");
+    return 1;
+#endif
   } else if (command == "dump_to_stdout") {
     InstallFailureWriter(WriteToStdout);
     abort();
+  } else if (command == "installed") {
+    fprintf(stderr, "signal handler installed: %s\n",
+        IsFailureSignalHandlerInstalled() ? "true" : "false");
   } else {
     // Tell the shell script
     puts("OK");

--- a/src/stacktrace_windows-inl.h
+++ b/src/stacktrace_windows-inl.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2000 - 2007, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Portable implementation - just use glibc
+//
+// Note:  The glibc implementation may cause a call to malloc.
+// This can cause a deadlock in HeapProfiler.
+#include <execinfo.h>
+#include <string.h>
+#include "stacktrace.h"
+
+_START_GOOGLE_NAMESPACE_
+
+// If you change this function, also change GetStackFrames below.
+int GetStackTrace(void** result, int max_depth, int skip_count) {
+  static const int kStackLength = 64;
+  void * stack[kStackLength];
+  int size;
+
+  size = backtrace(stack, kStackLength);
+  skip_count++;  // we want to skip the current frame as well
+  int result_count = size - skip_count;
+  if (result_count < 0)
+    result_count = 0;
+  if (result_count > max_depth)
+    result_count = max_depth;
+  for (int i = 0; i < result_count; i++)
+    result[i] = stack[i + skip_count];
+
+  return result_count;
+}
+
+_END_GOOGLE_NAMESPACE_

--- a/src/stacktrace_windows-inl.h
+++ b/src/stacktrace_windows-inl.h
@@ -31,13 +31,14 @@
 //
 // Windows implementation - just use CaptureStackBackTrace
 
+#include "config.h"
 #include "port.h"
 #include "stacktrace.h"
 #include <DbgHelp.h>
 
 _START_GOOGLE_NAMESPACE_
 
-// If you change this function, also change GetStackFrames below.
+GOOGLE_GLOG_DLL_DECL
 int GetStackTrace(void** result, int max_depth, int skip_count) {
   if (max_depth > 64) {
     max_depth = 64;

--- a/src/stacktrace_windows-inl.h
+++ b/src/stacktrace_windows-inl.h
@@ -33,54 +33,18 @@
 
 #include "port.h"
 #include "stacktrace.h"
-#include "Dbghelp.h"
-#include <vector>
+#include <DbgHelp.h>
 
 _START_GOOGLE_NAMESPACE_
 
-static bool ready_to_run = false;
-class StackTraceInit {
-public:
-  HANDLE hProcess;
-  StackTraceInit() {
-    // Initialize the symbol handler
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680344(v=vs.85).aspx
-    hProcess = GetCurrentProcess();
-    SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
-    SymInitialize(hProcess, NULL, true);
-    ready_to_run = true;
-  }
-  ~StackTraceInit() {
-    SymCleanup(hProcess);
-    ready_to_run = false;
-  }
-};
-
-static const StackTraceInit module_initializer;  // Force initialization
-
 // If you change this function, also change GetStackFrames below.
 int GetStackTrace(void** result, int max_depth, int skip_count) {
-  if (!ready_to_run) {
-    return 0;
-  }
-  skip_count++;  // we want to skip the current frame as well
   if (max_depth > 64) {
     max_depth = 64;
   }
-  std::vector<void*> stack(max_depth);
+  skip_count++;  // we want to skip the current frame as well
   // This API is thread-safe (moreover it walks only the current thread).
-  int size = CaptureStackBackTrace(skip_count, max_depth, &stack[0], NULL);
-  for (int i = 0; i < size; ++i) {
-    // Resolve symbol information from address.
-    char buffer[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
-    SYMBOL_INFO* symbol = reinterpret_cast<SYMBOL_INFO*>(buffer);
-    symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
-    symbol->MaxNameLen = MAX_SYM_NAME;
-    SymFromAddr(module_initializer.hProcess, reinterpret_cast<DWORD64>(stack[i]), 0, symbol);
-    result[i] = stack[i];
-  }
-
-  return size;
+  return CaptureStackBackTrace(skip_count, max_depth, result, NULL);
 }
 
 _END_GOOGLE_NAMESPACE_

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -837,6 +837,66 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
 
 _END_GOOGLE_NAMESPACE_
 
+#elif defined(OS_WINDOWS)
+
+#include <DbgHelp.h>
+
+_START_GOOGLE_NAMESPACE_
+
+class SymInitializer {
+public:
+  HANDLE process = NULL;
+  bool ready = false;
+  SymInitializer() {
+    // Initialize the symbol handler.
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680344(v=vs.85).aspx
+    process = GetCurrentProcess();
+    // Defer symbol loading.
+    // We do not request undecorated symbols with SYMOPT_UNDNAME
+    // because the mangling library calls UnDecorateSymbolName.
+    SymSetOptions(SYMOPT_DEFERRED_LOADS);
+    if (SymInitialize(process, NULL, true)) {
+      ready = true;
+    }
+  }
+  ~SymInitializer() {
+    SymCleanup(process);
+    // We do not need to close `HANDLE process` because it's a "pseudo handle."
+  }
+private:
+  SymInitializer(const SymInitializer&);
+  SymInitializer& operator=(const SymInitializer&);
+};
+
+static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
+                                                      int out_size) {
+  const static SymInitializer symInitializer;
+  if (!symInitializer.ready) {
+    return false;
+  }
+  // Resolve symbol information from address.
+  // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680578(v=vs.85).aspx
+  char buf[sizeof(SYMBOL_INFO) + MAX_SYM_NAME];
+  SYMBOL_INFO *symbol = reinterpret_cast<SYMBOL_INFO *>(buf);
+  symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+  symbol->MaxNameLen = MAX_SYM_NAME;
+  // We use the ANSI version to ensure the string type is always `char *`.
+  // This could break if a symbol has Unicode in it.
+  BOOL ret = SymFromAddr(symInitializer.process,
+                         reinterpret_cast<DWORD64>(pc), 0, symbol);
+  if (ret == 1 && static_cast<int>(symbol->NameLen) < out_size) {
+    // `NameLen` does not include the null terminating character.
+    strncpy(out, symbol->Name, static_cast<size_t>(symbol->NameLen) + 1);
+    out[static_cast<size_t>(symbol->NameLen)] = '\0';
+    // Symbolization succeeded.  Now we try to demangle the symbol.
+    DemangleInplace(out, out_size);
+    return true;
+  }
+  return false;
+}
+
+_END_GOOGLE_NAMESPACE_
+
 #else
 # error BUG: HAVE_SYMBOLIZE was wrongly set
 #endif

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -840,6 +840,7 @@ _END_GOOGLE_NAMESPACE_
 #elif defined(OS_WINDOWS)
 
 #include <DbgHelp.h>
+#pragma comment(lib, "DbgHelp")
 
 _START_GOOGLE_NAMESPACE_
 

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -137,17 +137,19 @@ static void DumpStackTraceAndExit() {
   DumpStackTrace(1, DebugWriteToStderr, NULL);
 
   // TOOD(hamaji): Use signal instead of sigaction?
-#ifdef HAVE_SIGACTION
   if (IsFailureSignalHandlerInstalled()) {
     // Set the default signal handler for SIGABRT, to avoid invoking our
     // own signal handler installed by InstallFailureSignalHandler().
+#ifdef HAVE_SIGACTION
     struct sigaction sig_action;
     memset(&sig_action, 0, sizeof(sig_action));
     sigemptyset(&sig_action.sa_mask);
     sig_action.sa_handler = SIG_DFL;
     sigaction(SIGABRT, &sig_action, NULL);
-  }
+#elif defined(OS_WINDOWS)
+    signal(SIGABRT, SIG_DFL);
 #endif  // HAVE_SIGACTION
+  }
 
   abort();
 }

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -133,6 +133,9 @@
 #elif defined(OS_MACOSX) && defined(HAVE_DLADDR)
 // Use dladdr to symbolize.
 # define HAVE_SYMBOLIZE
+#elif defined(OS_WINDOWS)
+// Use DbgHelp to symbolize
+# define HAVE_SYMBOLIZE
 #endif
 
 #ifndef ARRAYSIZE

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -99,6 +99,8 @@
 //    malloc() from the unwinder.  This is a problem because we're
 //    trying to use the unwinder to instrument malloc().
 //
+// 4) The Windows API CaptureStackTrace.
+//
 // Note: if you add a new implementation here, make sure it works
 // correctly when GetStackTrace() is called with max_depth == 0.
 // Some code may do that.
@@ -112,6 +114,8 @@
 #  define STACKTRACE_H "stacktrace_x86_64-inl.h"
 # elif (defined(__ppc__) || defined(__PPC__)) && __GNUC__ >= 2
 #  define STACKTRACE_H "stacktrace_powerpc-inl.h"
+# elif defined(OS_WINDOWS)
+#  define STACKTRACE_H "stacktrace_windows-inl.h"
 # endif
 #endif
 
@@ -142,6 +146,9 @@ namespace glog_internal_namespace_ {
 
 #ifdef HAVE___ATTRIBUTE__
 # define ATTRIBUTE_NOINLINE __attribute__ ((noinline))
+# define HAVE_ATTRIBUTE_NOINLINE
+#elif defined(OS_WINDOWS)
+# define ATTRIBUTE_NOINLINE __declspec(noinline)
 # define HAVE_ATTRIBUTE_NOINLINE
 #else
 # define ATTRIBUTE_NOINLINE


### PR DESCRIPTION
This set of patches implements the stack trace, symbolizer, and demangler for Windows, and their unit tests. It utilizes the Windows debugging APIs in `"Dbghelp.h"`.

There is one `TODO` for `IsFailureSignalHandlerInstalled` as I'm unsure yet how to implement it for Windows. That said, in order to make stack trace reporting work "as expected" for test failures, the data dump needs to be done immediately, instead of in the signal handler (see commit message for details).

I've integration tested this with Mesos, and so far it is working well. I've also updated the unit tests where appropriate.