### PR TITLE
Add __declspec(noreturn) on Win

### DIFF
--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -1250,7 +1250,7 @@ public:
   void SendToSyslogAndLog();  // Actually dispatch to syslog and the logs
 
   // Call abort() or similar to perform LOG(FATAL) crash.
-  static void  Fail();
+  static void __declspec(noreturn) Fail();
 
   std::ostream& stream();
 
@@ -1298,7 +1298,7 @@ class GOOGLE_GLOG_DLL_DECL LogMessageFatal : public LogMessage {
  public:
   LogMessageFatal(const char* file, int line);
   LogMessageFatal(const char* file, int line, const CheckOpString& result);
-   ~LogMessageFatal();
+  __declspec(noreturn) ~LogMessageFatal();
 };
 
 // A non-macro interface to the log facility; (useful
@@ -1602,7 +1602,7 @@ class GOOGLE_GLOG_DLL_DECL NullStreamFatal : public NullStream {
   NullStreamFatal() { }
   NullStreamFatal(const char* file, int line, const CheckOpString& result) :
       NullStream(file, line, result) { }
-   ~NullStreamFatal() throw () { _exit(1); }
+  __declspec(noreturn) ~NullStreamFatal() throw () { _exit(1); }
 };
 
 // Install a signal handler that will dump signal information and a stack

--- a/src/windows/preprocess.sh
+++ b/src/windows/preprocess.sh
@@ -95,7 +95,7 @@ DLLDEF_DEFINES="\
          -e "s!@ac_cv_have_libgflags@!0!g" \
          -e "s!@ac_cv_have___builtin_expect@!0!g" \
          -e "s!@ac_cv_cxx_using_operator@!1!g" \
-         -e "s!@ac_cv___attribute___noreturn@!!g" \
+         -e "s!@ac_cv___attribute___noreturn@!__declspec(noreturn)!g" \
          -e "s!@ac_cv___attribute___noinline@!!g" \
          -e "s!@ac_cv___attribute___printf_4_5@!!g" \
          -e "s!@ac_google_attribute@!${HAVE___ATTRIBUTE__:-0}!g" \


### PR DESCRIPTION
Currently cl.exe doesn't know LOG(FATAL) exits the program. Set
__declspec(noreturn).