### PR TITLE
Backport internal changes

### DIFF
--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -282,7 +282,7 @@ void TestLogging(bool check_counts) {
 }
 
 static void NoAllocNewHook() {
-  CHECK(false) << "unexpected new";
+  LOG(FATAL) << "unexpected new";
 }
 
 struct NewHook {

--- a/src/stacktrace_x86-inl.h
+++ b/src/stacktrace_x86-inl.h
@@ -93,16 +93,23 @@ static void **NextStackFrame(void **old_sp) {
 // If you change this function, also change GetStackFrames below.
 int GetStackTrace(void** result, int max_depth, int skip_count) {
   void **sp;
-#ifdef __i386__
+
+#ifdef __GNUC__
+#if __GNUC__ * 100 + __GNUC_MINOR__ >= 402
+#define USE_BUILTIN_FRAME_ADDRESS
+#endif
+#endif
+
+#ifdef USE_BUILTIN_FRAME_ADDRESS
+  sp = reinterpret_cast<void**>(__builtin_frame_address(0));
+#elif defined(__i386__)
   // Stack frame format:
   //    sp[0]   pointer to previous frame
   //    sp[1]   caller address
   //    sp[2]   first argument
   //    ...
   sp = (void **)&result - 2;
-#endif
-
-#ifdef __x86_64__
+#elif defined(__x86_64__)
   // __builtin_frame_address(0) can return the wrong address on gcc-4.1.0-k8
   unsigned long rbp;
   // Move the value of the register %rbp into the local variable rbp.

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -99,7 +99,13 @@ TEST(Symbolize, Symbolize) {
 
   // Compilers should give us pointers to them.
   EXPECT_STREQ("nonstatic_func", TrySymbolize((void *)(&nonstatic_func)));
-  EXPECT_STREQ("static_func", TrySymbolize((void *)(&static_func)));
+
+  // The name of an internal linkage symbol is not specified; allow either a
+  // mangled or an unmangled name here.
+  const char *static_func_symbol = TrySymbolize((void *)(&static_func));
+  CHECK(NULL != static_func_symbol);
+  EXPECT_TRUE(strcmp("static_func", static_func_symbol) == 0 ||
+              strcmp("static_func()", static_func_symbol) == 0);
 
   EXPECT_TRUE(NULL == TrySymbolize(NULL));
 }
@@ -267,9 +273,13 @@ TEST(Symbolize, SymbolizeStackConsumption) {
   EXPECT_GT(stack_consumed, 0);
   EXPECT_LT(stack_consumed, kStackConsumptionUpperLimit);
 
+  // The name of an internal linkage symbol is not specified; allow either a
+  // mangled or an unmangled name here.
   symbol = SymbolizeStackConsumption((void *)(&static_func),
                                      &stack_consumed);
-  EXPECT_STREQ("static_func", symbol);
+  CHECK(NULL != symbol);
+  EXPECT_TRUE(strcmp("static_func", symbol) == 0 ||
+              strcmp("static_func()", symbol) == 0);
   EXPECT_GT(stack_consumed, 0);
   EXPECT_LT(stack_consumed, kStackConsumptionUpperLimit);
 }

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -260,8 +260,13 @@ static const char *SymbolizeStackConsumption(void *pc, int *stack_consumed) {
   return g_symbolize_result;
 }
 
+#ifdef __ppc64__
+// Symbolize stack consumption should be within 4kB.
+const int kStackConsumptionUpperLimit = 4096;
+#else
 // Symbolize stack consumption should be within 2kB.
 const int kStackConsumptionUpperLimit = 2048;
+#endif
 
 TEST(Symbolize, SymbolizeStackConsumption) {
   int stack_consumed;

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -349,4 +349,12 @@ _END_GOOGLE_NAMESPACE_
 // Make an implementation of stacktrace compiled.
 #ifdef STACKTRACE_H
 # include STACKTRACE_H
+# if 0
+// For include scanners which can't handle macro expansions.
+#  include "stacktrace_libunwind-inl.h"
+#  include "stacktrace_x86-inl.h"
+#  include "stacktrace_x86_64-inl.h"
+#  include "stacktrace_powerpc-inl.h"
+#  include "stacktrace_generic-inl.h"
+# endif
 #endif

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -39,7 +39,9 @@
 #elif defined(__CYGWIN__) || defined(__CYGWIN32__)
 # define OS_CYGWIN
 #elif defined(linux) || defined(__linux) || defined(__linux__)
-# define OS_LINUX
+# ifndef OS_LINUX
+#  define OS_LINUX
+# endif
 #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
 # define OS_MACOSX
 #elif defined(__FreeBSD__)


### PR DESCRIPTION
PTAL Ukai-san?

This contains changes which are done after the last sync (long time ago) and looked useful. The ignored changes were mostly changes for our internal BUILD manifests.

It seemed ee9d487 and a6266db were done even before the last sync. I picked them as they were required  for the internal build.