### PR TITLE
SetLogFilenameExtension extension as a suffix to log file name

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -903,8 +903,8 @@ void LogFileObject::FlushUnlocked(){
 }
 
 bool LogFileObject::CreateLogfile(const string& time_pid_string) {
-  string string_filename = base_filename_+filename_extension_+
-                           time_pid_string;
+  string string_filename = base_filename_+ time_pid_string+
+                           filename_extension_;
   const char* filename = string_filename.c_str();
   int fd = open(filename, O_WRONLY | O_CREAT | O_EXCL, FLAGS_logfile_mode);
   if (fd == -1) return false;


### PR DESCRIPTION
Fix for https://github.com/google/glog/issues/124.