### PR TITLE
Two fixes for zero allocation logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,17 +203,24 @@ int main() { }
 " HAVE_CXX11_TLS)
 
 check_cxx_source_compiles ("
+__thread int tls;
+int main() { }
+" HAVE_GNUC_TLS)
+
+check_cxx_source_compiles ("
 __attribute__((thread)) int tls;
 int main() { }
 " HAVE_CYGWIN_TLS)
 
 if (WITH_TLS)
-  if (HAVE_CYGWIN_TLS)
+  if (HAVE_CXX11_TLS)
+    set (GLOG_THREAD_LOCAL_STORAGE thread_local)
+  elseif (HAVE_GNUC_TLS)
+    set (GLOG_THREAD_LOCAL_STORAGE __thread)
+  elseif (HAVE_CYGWIN_TLS)
     set (GLOG_THREAD_LOCAL_STORAGE "__attribute__((thread))")
   elseif (HAVE_MSVC_TLS)
     set (GLOG_THREAD_LOCAL_STORAGE "__declspec(thread)")
-  elseif (HAVE_CXX11_TLS)
-    set (GLOG_THREAD_LOCAL_STORAGE thread_local)
   endif (HAVE_CYGWIN_TLS)
 endif (WITH_TLS)
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -30,7 +30,7 @@
 /* Define to 1 if you have the <libunwind.h> header file. */
 #undef HAVE_LIBUNWIND_H
 
-/* define if you have google gflags library */
+/* Define if you have Google gflags library */
 #undef HAVE_LIB_GFLAGS
 
 /* define if you have google gmock library */


### PR DESCRIPTION
- Do not use non-POD type for TLS. This is for Issue #213.
- Use GNU's __thread if it's available. On my linux box, cmake
  wrongly thinks __attribute__((thread)), which is for Cygwin,
  is available.