### PR TITLE
Fix LOG_EVERY_N with clang -Wunused-local-typedef

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -934,9 +934,6 @@ struct CrashReason;
 bool IsFailureSignalHandlerInstalled();
 }  // namespace glog_internal_namespace_
 
-#define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
-  typedef @ac_google_namespace@::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
-
 #define LOG_EVERY_N(severity, n)                                        \
   SOME_KIND_OF_LOG_EVERY_N(severity, (n), @ac_google_namespace@::LogMessage::SendToLog)
 

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -938,9 +938,6 @@ bool IsFailureSignalHandlerInstalled();
   typedef @ac_google_namespace@::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
 
 #define LOG_EVERY_N(severity, n)                                        \
-  GOOGLE_GLOG_COMPILE_ASSERT(@ac_google_namespace@::GLOG_ ## severity < \
-                             @ac_google_namespace@::NUM_SEVERITIES,     \
-                             INVALID_REQUESTED_LOG_SEVERITY);           \
   SOME_KIND_OF_LOG_EVERY_N(severity, (n), @ac_google_namespace@::LogMessage::SendToLog)
 
 #define SYSLOG_EVERY_N(severity, n) \

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -938,9 +938,6 @@ struct CrashReason;
 bool IsFailureSignalHandlerInstalled();
 }  // namespace glog_internal_namespace_
 
-#define GOOGLE_GLOG_COMPILE_ASSERT(expr, msg) \
-  typedef google::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
-
 #define LOG_EVERY_N(severity, n)                                        \
   SOME_KIND_OF_LOG_EVERY_N(severity, (n), google::LogMessage::SendToLog)
 

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -942,9 +942,6 @@ bool IsFailureSignalHandlerInstalled();
   typedef google::glog_internal_namespace_::CompileAssert<(bool(expr))> msg[bool(expr) ? 1 : -1]
 
 #define LOG_EVERY_N(severity, n)                                        \
-  GOOGLE_GLOG_COMPILE_ASSERT(google::GLOG_ ## severity < \
-                             google::NUM_SEVERITIES,     \
-                             INVALID_REQUESTED_LOG_SEVERITY);           \
   SOME_KIND_OF_LOG_EVERY_N(severity, (n), google::LogMessage::SendToLog)
 
 #define SYSLOG_EVERY_N(severity, n) \


### PR DESCRIPTION
Please note, this should wait until PR #224 has been submitted as that PR includes adding me to the contributors.

Glog uses a pre-C++11 compile time assert to verify the validity of
the severity parameter for LOG_EVERY_N. Unfortunately, some compilers
will complain about the usage of LOG_EVERY_N with
"-Wunused-local-typedef" due to the way the compile time assert is
constructed. This makes it impossible to use LOG_EVERY_N with this
warning treated as an error.

The fix simply removes the assert entirely. This is safe to do since
you can't put anything invalid into the severity parameters without
generating a compile error elsewhere. This has been safe to do ever
since the GLOG_ prefixes were added as part of 6febec361e.

Fixes #223