### PR TITLE
#253: Use MS preprocessor idiom to disable warning

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1148,11 +1148,12 @@ public:
   // http://msdn.microsoft.com/en-us/library/3tdb471s(VS.80).aspx
   // Let's just ignore the warning.
 #ifdef _MSC_VER
+# pragma warning(push)
 # pragma warning(disable: 4275)
 #endif
   class GOOGLE_GLOG_DLL_DECL LogStream : public std::ostream {
 #ifdef _MSC_VER
-# pragma warning(default: 4275)
+# pragma warning(pop)
 #endif
   public:
     LogStream(char *buf, int len, int ctr)


### PR DESCRIPTION
This PR solves a problem with re-enabled 4275 warning after including <glog/logging.h>