### PR TITLE
remove unnecessary const_cast<char *> in raw_logging.cc

### DIFF
--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -131,7 +131,7 @@ void RawLog__(LogSeverity severity, const char* file, int line,
            1 + t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec,
            last_usecs_for_raw_log,
            static_cast<unsigned int>(GetTID()),
-           const_basename(const_cast<char *>(file)), line);
+           const_basename(file), line);
 
   // Record the position and size of the buffer after the prefix
   const char* msg_start = buf;


### PR DESCRIPTION
Since afd586a5d5c9, glog has shipped a "const_basename" function
which takes `const char *` and returns a `const char *` pointing to
(a substring of) the input string. This was done as part of a windows
support commit -- previously they used the `basename` function which
takes `char *` and wasn't available on windows.

The `const_cast` may have been necessary at that time, but now it
isn't since we have `const_basename`.

It's also a very dangerous cast because when using the logging
macros, the pointer is usually to the string literal provided by
`__FILE__`, and accessing this pointer as a `char *` yields undefined
behavior, no diagnostic required.

I believe there was no undefined behavior here, because the `char *`
that results is immediately converted to `const char *` as an argument
to `const_basename`. However, this is still a source code improvement.