### PR TITLE
add DCHECK_NEAR

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1000,6 +1000,7 @@ const LogSeverity GLOG_0 = GLOG_ERROR;
 #define DCHECK_STRCASEEQ(str1, str2) CHECK_STRCASEEQ(str1, str2)
 #define DCHECK_STRNE(str1, str2) CHECK_STRNE(str1, str2)
 #define DCHECK_STRCASENE(str1, str2) CHECK_STRCASENE(str1, str2)
+#define DCHECK_NEAR(val1, val2, margin) CHECK_NEAR(val1, val2, margin)
 
 #else  // !DCHECK_IS_ON()
 
@@ -1081,6 +1082,11 @@ const LogSeverity GLOG_0 = GLOG_ERROR;
   GLOG_MSVC_PUSH_DISABLE_WARNING(4127) \
   while (false) \
     GLOG_MSVC_POP_WARNING() CHECK_STRCASENE(str1, str2)
+
+#define DCHECK_NEAR(str1, str2, margin) \
+  GLOG_MSVC_PUSH_DISABLE_WARNING(4127) \
+  while (false) \
+    GLOG_MSVC_POP_WARNING() CHECK_NEAR(str1, str2, margin)
 
 #endif  // DCHECK_IS_ON()
 

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -543,6 +543,7 @@ void TestCHECK() {
   CHECK_LE(1, 2);
   CHECK_GT(2, 1);
   CHECK_LT(1, 2);
+  CHECK_NEAR(1, 2, 1);
 
   // Tests using CHECK*() on anonymous enums.
   // Apple's GCC doesn't like this.
@@ -571,6 +572,7 @@ void TestDCHECK() {
   DCHECK_LE(1, 2);
   DCHECK_GT(2, 1);
   DCHECK_LT(1, 2);
+  DCHECK_NEAR(1, 2, 1);
 
   auto_ptr<int64> sptr(new int64);
   int64* ptr = DCHECK_NOTNULL(sptr.get());


### PR DESCRIPTION
I went to use this macro and noticed that it was missing. Seems like it should exist.

Tried to add a symmetric test for `CHECK_NEAR`, but nothing no such test appeared to exist, so I added a extremely simple test similar to existing tests.

I wasn't sure if I should update `src/windows/glog/logging.h` or if that was unintentionally in the repo to begin with.