### PR TITLE
Update gflags to latest master

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,9 @@
-git_repository(
+http_archive(
     name = "com_github_gflags_gflags",
-    remote = "https://github.com/gflags/gflags.git",
-    tag = 'v2.2.1',
+    sha256 = "6e16c8bc91b1310a44f3965e616383dbda48f83e8c1eaa2370a215057b00cabe",
+    strip_prefix = "gflags-77592648e3f3be87d6c7123eb81cbad75f9aef5a",
+    urls = [
+        "https://mirror.bazel.build/github.com/gflags/gflags/archive/77592648e3f3be87d6c7123eb81cbad75f9aef5a.tar.gz",
+        "https://github.com/gflags/gflags/archive/77592648e3f3be87d6c7123eb81cbad75f9aef5a.tar.gz",
+    ],
 )

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -113,7 +113,7 @@ EOF
             'src/config.h.cmake.in',
         ],
         outs = [
-            'glog_internal/src/config.h',
+            'glog_internal/config.h',
         ],
         cmd = "awk '{ gsub(/^#cmakedefine/, \"//cmakedefine\"); print; }' $< > $@",
     )


### PR DESCRIPTION
This means that gflags no longer leaks config.h (https://github.com/gflags/gflags/commit/57ceb0ecc8bf5c129bf99fa9472b25342daecf9e),
so I had to fix a bug in glog.bzl where config.h is generated at the wrong path.

I also switched to the best-practice for depending on git repositories,
ie using http_archive with a mirror.

@iirina For Bazel review.