### PR TITLE
Use target gflags instead of old VARIABLES

### DIFF
--- a/cmake/DetermineGflagsNamespace.cmake
+++ b/cmake/DetermineGflagsNamespace.cmake
@@ -34,8 +34,8 @@ int main(int argc, char**argv)
       try_compile (${VARIABLE}
         "${CMAKE_BINARY_DIR}" "${_check_file}"
         COMPILE_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}" -DGFLAGS_NAMESPACE=${_namespace}
-        LINK_LIBRARIES "${gflags_LIBRARIES}"
-        CMAKE_FLAGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} "-DINCLUDE_DIRECTORIES:STRING=${gflags_INCLUDE_DIR}"
+        LINK_LIBRARIES gflags
+        CMAKE_FLAGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         OUTPUT_VARIABLE OUTPUT)
 
       if (${VARIABLE})


### PR DESCRIPTION
As mentioned in [Use gflags ALIAS target instead of ${gflags_XXX} variables #198](https://github.com/google/glog/issues/198) do the same for the try_compile command...