### PR TITLE
Add workaround to build on macOS

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -53,9 +53,8 @@ def glog_library(namespace='google', with_gflags=1):
             '-Wno-unused-function',
             '-Wno-unused-local-typedefs',
             '-Wno-unused-variable',
+            "-DGLOG_BAZEL_BUILD",
             # Inject a C++ namespace.
-            "-D_START_GOOGLE_NAMESPACE_='namespace %s {'" % namespace,
-            "-D_END_GOOGLE_NAMESPACE_='}'",
             "-DGOOGLE_NAMESPACE='%s'" % namespace,
             # Allows src/base/mutex.h to include pthread.h.
             '-DHAVE_PTHREAD',

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -180,8 +180,20 @@
 /* Version number of package */
 #cmakedefine VERSION
 
+#ifdef GLOG_BAZEL_BUILD
+
+/* TODO(rodrigoq): remove this workaround once bazel#3979 is resolved:
+ * https://github.com/bazelbuild/bazel/issues/3979 */
+#define _START_GOOGLE_NAMESPACE_ namespace GOOGLE_NAMESPACE {
+
+#define _END_GOOGLE_NAMESPACE_ }
+
+#else
+
 /* Stops putting the code inside the Google namespace */
 #cmakedefine _END_GOOGLE_NAMESPACE_ ${_END_GOOGLE_NAMESPACE_}
 
 /* Puts following code inside the Google namespace */
 #cmakedefine _START_GOOGLE_NAMESPACE_ ${_START_GOOGLE_NAMESPACE_}
+
+#endif


### PR DESCRIPTION
This works around https://github.com/bazelbuild/bazel/issues/3979,
and so closes #282.