### PR TITLE
CMake Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,21 +8,14 @@ if (POLICY CMP0063)
   cmake_policy (SET CMP0063 NEW)
 endif (POLICY CMP0063)
 
-project (glog)
-
-set (GLOG_MAJOR_VERSION 0)
-set (GLOG_MINOR_VERSION 3)
-set (GLOG_PATCH_VERSION 5)
-
-set (GLOG_VERSION
-  ${GLOG_MAJOR_VERSION}.${GLOG_MINOR_VERSION}.${GLOG_PATCH_VERSION})
+project(glog VERSION 0.3.5 LANGUAGES C CXX)
 
 set (CPACK_PACKAGE_NAME glog)
 set (CPACK_PACKAGE_DESCRIPTION_SUMMARY "")
-set (CPACK_PACKAGE_VERSION_MAJOR ${GLOG_MAJOR_VERSION})
-set (CPACK_PACKAGE_VERSION_MINOR ${GLOG_MINOR_VERSION})
-set (CPACK_PACKAGE_VERSION_PATCH ${GLOG_PATCH_VERSION})
-set (CPACK_PACKAGE_VERSION ${GLOG_VERSION})
+set (CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+set (CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+set (CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+set (CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
 
 option (WITH_GFLAGS "Use gflags" ON)
 option (WITH_THREADS "Enable multithreading support" ON)
@@ -433,8 +426,8 @@ if (gflags_FOUND)
   endif (NOT BUILD_SHARED_LIBS)
 endif (gflags_FOUND)
 
-set_target_properties (glog PROPERTIES VERSION ${GLOG_MAJOR_VERSION})
-set_target_properties (glog PROPERTIES SOVERSION ${GLOG_VERSION})
+set_target_properties (glog PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties (glog PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
 
 if (WIN32)
   target_compile_definitions (glog PUBLIC GLOG_NO_ABBREVIATED_SEVERITIES)
@@ -618,7 +611,7 @@ configure_package_config_file (glog-config.cmake.in
   NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 
 write_basic_package_version_file (glog-config-version.cmake VERSION
-  ${GLOG_VERSION} COMPATIBILITY SameMajorVersion)
+  ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion)
 
 export (TARGETS glog NAMESPACE glog:: FILE glog-targets.cmake)
 export (PACKAGE glog)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,6 @@ endif (POLICY CMP0063)
 
 project (glog)
 
-enable_testing ()
-
 set (GLOG_MAJOR_VERSION 0)
 set (GLOG_MINOR_VERSION 3)
 set (GLOG_PATCH_VERSION 5)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,6 +409,7 @@ add_compile_options ($<$<BOOL:${HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS}>:-Wno-unname
 add_library (glog
   ${GLOG_SRCS}
 )
+add_library(glog::glog ALIAS glog)
 
 set_target_properties (glog PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/cmake/INSTALL.md
+++ b/cmake/INSTALL.md
@@ -1,30 +1,81 @@
-Building Glog with CMake
-========================
+# Glog - CMake Support
 
-1. Create a build directory and `cd` to it.
-2. Run
-    ```bash
-    cmake path/to/glog
-    ```
+Glog comes with a CMake build script ([CMakeLists.txt](../CMakeLists.txt)) that can be used on a wide range of platforms.  
+If you don't have CMake installed already, you can download it for free from <http://www.cmake.org/>.
 
-3. Afterwards, generated files (GNU make, Visual Studio, etc.) can be used to
-   compile the project.
+CMake works by generating native makefiles or build projects that can be used in the compiler environment of your choice.  
+You can either build Glog with CMake as a standalone project or it can be incorporated into an existing CMake build for another project.
 
+## Table of Contents
 
-Consuming Glog in a CMake Project
-=================================
+- [Building Glog with CMake](#building-glog-with-cmake)
+- [Consuming Glog in a CMake Project](#consuming-glog-in-a-cmake-project)
+- [Incorporating Glog into a CMake Project](#incorporating-glog-into-a-cmake-project)
 
-To use Glog in your project `myproj`, use:
+## Building Glog with CMake
+
+When building Glog as a standalone project, on Unix-like systems with GNU Make as build tool, the typical workflow is:  
+
+1. Get the source code and change to it.
+e.g. cloning with git:
+```bash
+git clone git@github.com:google/glog.git
+cd glog
+```
+
+2. Run CMake to configure the build tree.
+```bash
+cmake -H. -Bbuild -G "Unix Makefiles"
+```
+note: To get the list of available generators (e.g. Visual Studio), use `-G ""`
+
+3. Afterwards, generated files can be used to compile the project.
+```bash
+cmake --build build
+```
+
+4. Test the build software (optional).
+```bash
+cmake --build build --target test
+```
+
+5. Install the built files (optional).
+```bash
+cmake --build build --target install
+```
+
+## Consuming Glog in a CMake Project
+
+If you have Glog installed in your system, you can use the CMake command
+`find_package()` to include it in your CMake Project.
 
 ```cmake
-cmake_minimum_required (VERSION 3.0)
-project (myproj)
+cmake_minimum_required(VERSION 3.0.2)
+project(myproj VERSION 1.0)
 
-find_package (glog 0.3.5 REQUIRED)
+find_package(glog 0.3.5 REQUIRED)
 
-add_executable (myapp main.cpp)
-target_link_libraries (myapp glog::glog)
+add_executable(myapp main.cpp)
+target_link_libraries(myapp glog::glog)
 ```
 
 Compile definitions and options will be added automatically to your target as
+needed.
+
+## Incorporating Glog into a CMake Project
+
+You can also use the CMake command `add_subdirectory()` to include Glog directly from a subdirectory of your project.  
+The **glog::glog** target is in this case an ALIAS library target for the **glog** library target. 
+
+```cmake
+cmake_minimum_required(VERSION 3.0.2)
+project(myproj VERSION 1.0)
+
+add_subdirectory(glog)
+
+add_executable(myapp main.cpp)
+target_link_libraries(myapp glog::glog)
+```
+
+Again, compile definitions and options will be added automatically to your target as
 needed.


### PR DESCRIPTION
Few patch to:
- Ease the use of glog as subproject (i.e. adding alias glog::glog)
- Better manage gflags dependencies
- Rework VERSION management using project() provided variables
cf https://cmake.org/cmake/help/v3.0/command/project.html