### PR TITLE
Resolve missing prototype warning

### DIFF
--- a/src/googletest.h
+++ b/src/googletest.h
@@ -110,6 +110,8 @@ using testing::InitGoogleTest;
 
 _START_GOOGLE_NAMESPACE_
 
+void InitGoogleTest(int*, char**);
+
 void InitGoogleTest(int*, char**) {}
 
 // The following is some bare-bones testing infrastructure

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -301,7 +301,7 @@ static GLogColor SeverityToColor(LogSeverity severity) {
 #ifdef OS_WINDOWS
 
 // Returns the character attribute for the given color.
-WORD GetColorAttribute(GLogColor color) {
+static WORD GetColorAttribute(GLogColor color) {
   switch (color) {
     case COLOR_RED:    return FOREGROUND_RED;
     case COLOR_GREEN:  return FOREGROUND_GREEN;
@@ -313,7 +313,7 @@ WORD GetColorAttribute(GLogColor color) {
 #else
 
 // Returns the ANSI color code for the given color.
-const char* GetAnsiColorCode(GLogColor color) {
+static const char* GetAnsiColorCode(GLogColor color) {
   switch (color) {
   case COLOR_RED:     return "1";
   case COLOR_GREEN:   return "2";
@@ -1677,6 +1677,7 @@ void LogToStderr() {
 namespace base {
 namespace internal {
 
+bool GetExitOnDFatal();
 bool GetExitOnDFatal() {
   MutexLock l(&log_mutex);
   return exit_on_dfatal;
@@ -1692,6 +1693,7 @@ bool GetExitOnDFatal() {
 // and the stack trace is not recorded.  The LOG(FATAL) *will* still
 // exit the program.  Since this function is used only in testing,
 // these differences are acceptable.
+void SetExitOnDFatal(bool value);
 void SetExitOnDFatal(bool value) {
   MutexLock l(&log_mutex);
   exit_on_dfatal = value;

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -1067,10 +1067,10 @@ TEST(Strerror, logging) {
 
 // Simple routines to look at the sizes of generated code for LOG(FATAL) and
 // CHECK(..) via objdump
-void MyFatal() {
+static void MyFatal() {
   LOG(FATAL) << "Failed";
 }
-void MyCheck(bool a, bool b) {
+static void MyCheck(bool a, bool b) {
   CHECK_EQ(a, b);
 }
 

--- a/src/signalhandler_unittest.cc
+++ b/src/signalhandler_unittest.cc
@@ -48,7 +48,7 @@ using namespace GFLAGS_NAMESPACE;
 
 using namespace GOOGLE_NAMESPACE;
 
-void* DieInThread(void*) {
+static void* DieInThread(void*) {
   // We assume pthread_t is an integral number or a pointer, rather
   // than a complex struct.  In some environments, pthread_self()
   // returns an uint64 but in some other environments pthread_self()
@@ -62,7 +62,7 @@ void* DieInThread(void*) {
   return NULL;
 }
 
-void WriteToStdout(const char* data, int size) {
+static void WriteToStdout(const char* data, int size) {
   if (write(STDOUT_FILENO, data, size) < 0) {
     // Ignore errors.
   }

--- a/src/stacktrace_unittest.cc
+++ b/src/stacktrace_unittest.cc
@@ -103,7 +103,7 @@ AddressRange expected_range[BACKTRACE_STEPS];
 
 //-----------------------------------------------------------------------//
 
-void CheckRetAddrIsInFunction(void *ret_addr, const AddressRange &range)
+static void CheckRetAddrIsInFunction(void *ret_addr, const AddressRange &range)
 {
   CHECK_GE(ret_addr, range.start);
   CHECK_LE(ret_addr, range.end);
@@ -112,7 +112,7 @@ void CheckRetAddrIsInFunction(void *ret_addr, const AddressRange &range)
 //-----------------------------------------------------------------------//
 
 void ATTRIBUTE_NOINLINE CheckStackTrace(int);
-void ATTRIBUTE_NOINLINE CheckStackTraceLeaf(void) {
+static void ATTRIBUTE_NOINLINE CheckStackTraceLeaf(void) {
   const int STACK_LEN = 10;
   void *stack[STACK_LEN];
   int size;
@@ -148,7 +148,7 @@ void ATTRIBUTE_NOINLINE CheckStackTraceLeaf(void) {
 //-----------------------------------------------------------------------//
 
 /* Dummy functions to make the backtrace more interesting. */
-void ATTRIBUTE_NOINLINE CheckStackTrace4(int i) {
+static void ATTRIBUTE_NOINLINE CheckStackTrace4(int i) {
   ADJUST_ADDRESS_RANGE_FROM_RA(&expected_range[2]);
   INIT_ADDRESS_RANGE(CheckStackTrace4, start, end, &expected_range[1]);
   DECLARE_ADDRESS_LABEL(start);
@@ -156,7 +156,7 @@ void ATTRIBUTE_NOINLINE CheckStackTrace4(int i) {
     CheckStackTraceLeaf();
   DECLARE_ADDRESS_LABEL(end);
 }
-void ATTRIBUTE_NOINLINE CheckStackTrace3(int i) {
+static void ATTRIBUTE_NOINLINE CheckStackTrace3(int i) {
   ADJUST_ADDRESS_RANGE_FROM_RA(&expected_range[3]);
   INIT_ADDRESS_RANGE(CheckStackTrace3, start, end, &expected_range[2]);
   DECLARE_ADDRESS_LABEL(start);
@@ -164,7 +164,7 @@ void ATTRIBUTE_NOINLINE CheckStackTrace3(int i) {
     CheckStackTrace4(j);
   DECLARE_ADDRESS_LABEL(end);
 }
-void ATTRIBUTE_NOINLINE CheckStackTrace2(int i) {
+static void ATTRIBUTE_NOINLINE CheckStackTrace2(int i) {
   ADJUST_ADDRESS_RANGE_FROM_RA(&expected_range[4]);
   INIT_ADDRESS_RANGE(CheckStackTrace2, start, end, &expected_range[3]);
   DECLARE_ADDRESS_LABEL(start);
@@ -172,7 +172,7 @@ void ATTRIBUTE_NOINLINE CheckStackTrace2(int i) {
     CheckStackTrace3(j);
   DECLARE_ADDRESS_LABEL(end);
 }
-void ATTRIBUTE_NOINLINE CheckStackTrace1(int i) {
+static void ATTRIBUTE_NOINLINE CheckStackTrace1(int i) {
   ADJUST_ADDRESS_RANGE_FROM_RA(&expected_range[5]);
   INIT_ADDRESS_RANGE(CheckStackTrace1, start, end, &expected_range[4]);
   DECLARE_ADDRESS_LABEL(start);

--- a/src/stl_logging_unittest.cc
+++ b/src/stl_logging_unittest.cc
@@ -71,7 +71,7 @@ struct user_hash {
   size_t operator()(int x) const { return x; }
 };
 
-void TestSTLLogging() {
+static void TestSTLLogging() {
   {
     // Test a sequence.
     vector<int> v;

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -634,7 +634,7 @@ OpenObjectFileContainingPcAndGetStartAddress(uint64_t pc,
 // bytes. Output will be truncated as needed, and a NUL character is always
 // appended.
 // NOTE: code from sandbox/linux/seccomp-bpf/demo.cc.
-char *itoa_r(intptr_t i, char *buf, size_t sz, int base, size_t padding) {
+static char *itoa_r(intptr_t i, char *buf, size_t sz, int base, size_t padding) {
   // Make sure we can write at least one NUL byte.
   size_t n = 1;
   if (n > sz)
@@ -696,7 +696,7 @@ char *itoa_r(intptr_t i, char *buf, size_t sz, int base, size_t padding) {
 
 // Safely appends string |source| to string |dest|.  Never writes past the
 // buffer size |dest_size| and guarantees that |dest| is null-terminated.
-void SafeAppendString(const char* source, char* dest, int dest_size) {
+static void SafeAppendString(const char* source, char* dest, int dest_size) {
   int dest_string_length = strlen(dest);
   SAFE_ASSERT(dest_string_length < dest_size);
   dest += dest_string_length;
@@ -709,7 +709,7 @@ void SafeAppendString(const char* source, char* dest, int dest_size) {
 // Converts a 64-bit value into a hex string, and safely appends it to |dest|.
 // Never writes past the buffer size |dest_size| and guarantees that |dest| is
 // null-terminated.
-void SafeAppendHexNumber(uint64_t value, char* dest, int dest_size) {
+static void SafeAppendHexNumber(uint64_t value, char* dest, int dest_size) {
   // 64-bit numbers in hex can have up to 16 digits.
   char buf[17] = {'\0'};
   SafeAppendString(itoa_r(value, buf, sizeof(buf), 16, 0), dest, dest_size);

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -82,6 +82,7 @@ static const char *TrySymbolize(void *pc) {
 
 // Make them C linkage to avoid mangled names.
 extern "C" {
+void nonstatic_func();
 void nonstatic_func() {
   volatile int a = 0;
   ++a;
@@ -300,6 +301,7 @@ inline void* always_inline inline_func() {
   return pc;
 }
 
+void* ATTRIBUTE_NOINLINE non_inline_func();
 void* ATTRIBUTE_NOINLINE non_inline_func() {
   register void *pc = NULL;
 #ifdef TEST_X86_32_AND_64
@@ -308,7 +310,7 @@ void* ATTRIBUTE_NOINLINE non_inline_func() {
   return pc;
 }
 
-void ATTRIBUTE_NOINLINE TestWithPCInsideNonInlineFunction() {
+static void ATTRIBUTE_NOINLINE TestWithPCInsideNonInlineFunction() {
 #if defined(TEST_X86_32_AND_64) && defined(HAVE_ATTRIBUTE_NOINLINE)
   void *pc = non_inline_func();
   const char *symbol = TrySymbolize(pc);
@@ -318,7 +320,7 @@ void ATTRIBUTE_NOINLINE TestWithPCInsideNonInlineFunction() {
 #endif
 }
 
-void ATTRIBUTE_NOINLINE TestWithPCInsideInlineFunction() {
+static void ATTRIBUTE_NOINLINE TestWithPCInsideInlineFunction() {
 #if defined(TEST_X86_32_AND_64) && defined(HAVE_ALWAYS_INLINE)
   void *pc = inline_func();  // Must be inlined.
   const char *symbol = TrySymbolize(pc);
@@ -330,7 +332,7 @@ void ATTRIBUTE_NOINLINE TestWithPCInsideInlineFunction() {
 }
 
 // Test with a return address.
-void ATTRIBUTE_NOINLINE TestWithReturnAddress() {
+static void ATTRIBUTE_NOINLINE TestWithReturnAddress() {
 #if defined(HAVE_ATTRIBUTE_NOINLINE)
   void *return_address = __builtin_return_address(0);
   const char *symbol = TrySymbolize(return_address);

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -84,7 +84,7 @@ static void DebugWriteToStderr(const char* data, void *) {
   }
 }
 
-void DebugWriteToString(const char* data, void *arg) {
+static void DebugWriteToString(const char* data, void *arg) {
   reinterpret_cast<string*>(arg)->append(data);
 }
 

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -62,6 +62,12 @@ _START_GOOGLE_NAMESPACE_
 
 namespace glog_internal_namespace_ {
 
+// Used by logging_unittests.cc so can't make it static here.
+GOOGLE_GLOG_DLL_DECL bool SafeFNMatch_(const char* pattern,
+                                       size_t patt_len,
+                                       const char* str,
+                                       size_t str_len);
+
 // Implementation of fnmatch that does not need 0-termination
 // of arguments and does not allocate any memory,
 // but we only support "*" and "?" wildcards, not the "[...]" patterns.


### PR DESCRIPTION
Makes compilation process less noisy even when using string compiler flags.

This is #81, but updated against latest master and created against a feature-branch.