### PR TITLE
Fix redefined warnings from config.h

### DIFF
--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -1,3 +1,6 @@
+#ifndef GLOG_CONFIG_H
+#define GLOG_CONFIG_H
+
 /* define if glog doesn't use RTTI */
 #cmakedefine DISABLE_RTTI
 
@@ -200,3 +203,5 @@
 #cmakedefine _START_GOOGLE_NAMESPACE_ ${_START_GOOGLE_NAMESPACE_}
 
 #endif
+
+#endif  // GLOG_CONFIG_H


### PR DESCRIPTION
The issue was caused by config.h header being included from both
header files and implementation files.

Proposed solution is to have regular header guard in the generated
config.h. Benefit of this solution is that it's least intrusive.
Downside is that it only solves issue for CMake build system, and
autoconf one is not fixed since header template is automatically
generated by autoheader who does not add header guard.