### PR TITLE
konsole family of terminfo supports colored output

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -255,6 +255,9 @@ static bool TerminalSupportsColor() {
       !strcmp(term, "xterm-color") ||
       !strcmp(term, "xterm-256color") ||
       !strcmp(term, "screen-256color") ||
+      !strcmp(term, "konsole") ||
+      !strcmp(term, "konsole-16color") ||
+      !strcmp(term, "konsole-256color") ||
       !strcmp(term, "screen") ||
       !strcmp(term, "linux") ||
       !strcmp(term, "cygwin");


### PR DESCRIPTION
Glog was missing colored output when running in terminal
who is set to konsole* TERM, even though the terminal
itself supports colored output.

Add extra terminfo to the check function, so now output
from Glog is properly colored.