### PR TITLE
Fix __attribute__((noreturn)) mismatch warning in Bazel build

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -69,6 +69,7 @@ def glog_library(namespace='google', with_gflags=1):
             '-DHAVE_SIGACTION',
             # For logging.cc.
             '-DHAVE_PREAD',
+            '-DHAVE___ATTRIBUTE__',
 
             # Include generated header files.
             '-I%s/glog_internal' % gendir,


### PR DESCRIPTION
This PR fixes mismatch of `__attribute__((noreturn))` in `LogMessage::Fail()`'s header and source in Bazel build.

The problem seems to be caused by incomplete autoconf emulation in `glog.bzl`.

This remove the `"'noreturn' function does return"`  warning that can be a trouble to build with `'-Werror'`.
