### PR TITLE
Fix mingw cross compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,18 @@ elseif (UNIX OR (APPLE AND HAVE_DLADDR))
   set (HAVE_SYMBOLIZE 1)
 endif (WIN32 OR CYGWIN)
 
+check_cxx_source_compiles ("
+#include <cstdlib>
+#include <time.h>
+int main()
+{
+    time_t timep;
+    struct tm result;
+    localtime_r(&timep, &result);
+    return EXIT_SUCCESS;
+}
+" HAVE_LOCALTIME_R)
+
 set (SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
 
 if (WITH_THREADS AND Threads_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ check_cxx_compiler_flag (-Wunnamed-type-template-args
 check_symbol_exists (snprintf stdio.h HAVE_SNPRINTF)
 
 check_library_exists (unwind get_static_proc_name "" HAVE_LIB_UNWIND)
-check_library_exists (DbgHelp UnDecorateSymbolName "" HAVE_DBGHELP)
+check_library_exists (dbghelp UnDecorateSymbolName "" HAVE_DBGHELP)
 
 find_library (UNWIND_LIBRARY NAMES unwind DOC "unwind library")
 mark_as_advanced (UNWIND_LIBRARY)
@@ -456,7 +456,7 @@ if (UNWIND_LIBRARY)
 endif (UNWIND_LIBRARY)
 
 if (HAVE_DBGHELP)
-   target_link_libraries (glog PUBLIC DbgHelp)
+   target_link_libraries (glog PUBLIC dbghelp)
 endif (HAVE_DBGHELP)
 
 if (HAVE_PTHREAD)

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -136,6 +136,9 @@
 /* define if symbolize support is available */
 #cmakedefine HAVE_SYMBOLIZE
 
+/* define if localtime_r is available in time.h */
+#cmakedefine HAVE_LOCALTIME_R
+
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
 #cmakedefine LT_OBJDIR

--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -39,8 +39,8 @@
 #include "demangle.h"
 
 #if defined(OS_WINDOWS)
-#include <DbgHelp.h>
-#pragma comment(lib, "DbgHelp")
+#include <dbghelp.h>
+#pragma comment(lib, "dbghelp")
 #endif
 
 _START_GOOGLE_NAMESPACE_

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -183,7 +183,7 @@ GLOG_DEFINE_string(log_backtrace_at, "",
 
 #ifndef HAVE_PREAD
 #if defined(OS_WINDOWS)
-#include <BaseTsd.h>
+#include <basetsd.h>
 #define ssize_t SSIZE_T
 #endif
 static ssize_t pread(int fd, void* buf, size_t count, off_t offset) {

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -847,10 +847,10 @@ _END_GOOGLE_NAMESPACE_
 #elif defined(OS_WINDOWS) || defined(OS_CYGWIN)
 
 #include <windows.h>
-#include <DbgHelp.h>
+#include <dbghelp.h>
 
 #ifdef _MSC_VER
-#pragma comment(lib, "DbgHelp")
+#pragma comment(lib, "dbghelp")
 #endif
 
 _START_GOOGLE_NAMESPACE_

--- a/src/windows/port.cc
+++ b/src/windows/port.cc
@@ -55,6 +55,12 @@ int safe_vsnprintf(char *str, size_t size, const char *format, va_list ap) {
   return _vsnprintf(str, size-1, format, ap);
 }
 
+#ifndef HAVE_LOCALTIME_R
+struct tm* localtime_r(const time_t* timep, struct tm* result) {
+  localtime_s(result, timep);
+  return result;
+}
+#endif // not HAVE_LOCALTIME_R
 #ifndef HAVE_SNPRINTF
 int snprintf(char *str, size_t size, const char *format, ...) {
   va_list ap;

--- a/src/windows/port.cc
+++ b/src/windows/port.cc
@@ -38,14 +38,7 @@
 
 #include "config.h"
 #include <stdarg.h>    // for va_list, va_start, va_end
-#include <string.h>    // for strstr()
-#include <assert.h>
-#include <string>
-#include <vector>
 #include "port.h"
-
-using std::string;
-using std::vector;
 
 // These call the windows _vsnprintf, but always NUL-terminate.
 int safe_vsnprintf(char *str, size_t size, const char *format, va_list ap) {

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -147,10 +147,12 @@ enum { PTHREAD_ONCE_INIT = 0 };   // important that this be 0! for SpinLock
 #define pthread_equal(pthread_t_1, pthread_t_2)  ((pthread_t_1)==(pthread_t_2))
 #endif // HAVE_PTHREAD
 
+#ifndef HAVE_LOCALTIME_R
 inline struct tm* localtime_r(const time_t* timep, struct tm* result) {
   localtime_s(result, timep);
   return result;
 }
+#endif
 
 inline char* strerror_r(int errnum, char* buf, size_t buflen) {
   strerror_s(buf, buflen, errnum);

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -136,19 +136,21 @@ typedef int pid_t;
 #endif  // _MSC_VER
 
 // ----------------------------------- THREADS
-#ifndef __MINGW32__
+#if defined(HAVE_PTHREAD)
+# include <pthread.h>
+#else // no PTHREAD
 typedef DWORD pthread_t;
 typedef DWORD pthread_key_t;
 typedef LONG pthread_once_t;
 enum { PTHREAD_ONCE_INIT = 0 };   // important that this be 0! for SpinLock
 #define pthread_self  GetCurrentThreadId
 #define pthread_equal(pthread_t_1, pthread_t_2)  ((pthread_t_1)==(pthread_t_2))
+#endif // HAVE_PTHREAD
 
 inline struct tm* localtime_r(const time_t* timep, struct tm* result) {
   localtime_s(result, timep);
   return result;
 }
-#endif
 
 inline char* strerror_r(int errnum, char* buf, size_t buflen) {
   strerror_s(buf, buflen, errnum);

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -148,11 +148,8 @@ enum { PTHREAD_ONCE_INIT = 0 };   // important that this be 0! for SpinLock
 #endif // HAVE_PTHREAD
 
 #ifndef HAVE_LOCALTIME_R
-inline struct tm* localtime_r(const time_t* timep, struct tm* result) {
-  localtime_s(result, timep);
-  return result;
-}
-#endif
+extern struct tm* GOOGLE_GLOG_DLL_DECL localtime_r(const time_t* timep, struct tm* result);
+#endif // not HAVE_LOCALTIME_R
 
 inline char* strerror_r(int errnum, char* buf, size_t buflen) {
   strerror_s(buf, buflen, errnum);


### PR DESCRIPTION
This patchset fixes cross compilation with mingw-w64 from Ubuntu 18.04 to Windows and mingw-w64 compiles on Appveyor
Referencing https://github.com/google/glog/issues/323

Compilations for MSVC 2017 win64 and mingw-w64 7.2.0 can be seen here
https://ci.appveyor.com/project/NeroBurner/glog/build/1.0.42/job/ivk3i16iag6ro3mr

Compilations with Ubuntu 14.04 (amd64/i386), Ubuntu 16.04 (amd64/i386), Ubuntu 18.04 (amd64) and cross compilation for Windows with mingw-w64 on Ubuntu 18.04 can be seen here
https://travis-ci.org/NeroBurner/glog/builds/386575502

I'll try to cleanup the CI pipeline so that it is possible to be merged an a later pull request