### PR TITLE
add custom target 'check' for more verbose tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -619,6 +619,10 @@ if (BUILD_TESTING)
   if (TARGET symbolize_unittest)
     add_test (NAME symbolize COMMAND symbolize_unittest)
   endif (TARGET symbolize_unittest)
+
+  add_custom_target(check ${CMAKE_COMMAND} -E env CTEST_OUTPUT_ON_FAILURE=1
+                    ${CMAKE_CTEST_COMMAND} -C $<CONFIG> --verbose
+                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif (BUILD_TESTING)
 
 install (TARGETS glog


### PR DESCRIPTION
adds a custom cmake target `check`. In case of an error in the testsuite the errors are printed to the terminal (instead of just telling the user which test failed). Very handy for CI systems