### PR TITLE
ci: add appveyor and travis config

### DIFF
--- a/.travis.ubuntu.sh
+++ b/.travis.ubuntu.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+set -x
+
+uname -a
+
+cmake -H. -B_build_${TOOLCHAIN} -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/${TOOLCHAIN}.cmake"
+cmake --build _build_${TOOLCHAIN} -- -j4
+
+if [ "$RUN_TESTS" = true ]; then
+	case "$TOOLCHAIN" in linux-mingw*)
+		echo "copy runtime libraries needed for tests into build directory"
+		cp /usr/x86_64-w64-mingw32/lib/libwinpthread-1.dll /usr/lib/gcc/x86_64-w64-mingw32/7.3-win32/{libstdc++-6.dll,libgcc_s_seh-1.dll} _build_${TOOLCHAIN}
+	esac
+	CTEST_OUTPUT_ON_FAILURE=1 cmake --build _build_${TOOLCHAIN} --target test
+fi
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,112 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+# define the build matrix
+env:
+  global:
+    - PROJECT_DIR: .
+    - TOOLCHAIN: gcc-cxx11
+    - BUILD_PACKAGES: cmake
+    - RUN_TESTS: true
+
+matrix:
+  include:
+    # Linux {
+
+    #   Ubuntu 14.04
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=trusty
+        BUILD_ARCH=amd64
+        BUILD_PACKAGES=cmake3
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=trusty
+        BUILD_ARCH=i386
+        BUILD_PACKAGES=cmake3
+    #   Ubuntu 16.04
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=xenial
+        BUILD_ARCH=amd64
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=xenial
+        BUILD_ARCH=i386
+    #   Ubuntu 18.04
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx98
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-gnuxx11
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=gcc-cxx17
+    # } // end Linux
+
+    # Windows build with mingw-w64 on Ubuntu 18.04
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=linux-mingw-w64-cxx11
+        BUILD_PACKAGES="cmake mingw-w64 wine-stable"
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=linux-mingw-w64-gnuxx11
+        BUILD_PACKAGES="cmake mingw-w64 wine-stable"
+    - os: linux
+      env: >
+        BUILD_FLAVOR=ubuntu
+        BUILD_RELEASE=bionic
+        BUILD_ARCH=amd64
+        TOOLCHAIN=linux-mingw-w64-cxx17
+        BUILD_PACKAGES="cmake mingw-w64 wine-stable"
+
+before_install:
+  # use the Dockerfile.<distro>.template file for building the image with sed magic
+  - |
+    sed \
+    -e "s/@BUILD_FLAVOR@/${BUILD_FLAVOR}/g" \
+    -e "s/@BUILD_RELEASE@/${BUILD_RELEASE}/g" \
+    -e "s/@BUILD_ARCH@/${BUILD_ARCH}/g" \
+    -e "s/@BUILD_PACKAGES@/${BUILD_PACKAGES}/g" \
+    Dockerfile.$BUILD_FLAVOR.template | tee Dockerfile.$BUILD_FLAVOR.$BUILD_RELEASE.$BUILD_ARCH
+  - docker build -f Dockerfile.$BUILD_FLAVOR.$BUILD_RELEASE.$BUILD_ARCH -t glog-devel .
+
+script: |
+  # run the respective .travis.<distro>.sh script
+  docker run \
+  -e BUILD_FLAVOR="$BUILD_FLAVOR" \
+  -e BUILD_RELEASE="$BUILD_RELEASE" \
+  -e BUILD_ARCH="$BUILD_ARCH" \
+  -e PROJECT_DIR="$PROJECT_DIR" \
+  -e TOOLCHAIN="$TOOLCHAIN" \
+  -e RUN_TESTS="$RUN_TESTS" \
+  -it glog-devel ./.travis.$BUILD_FLAVOR.sh
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,6 +624,7 @@ if (BUILD_TESTING)
 
   if (TARGET stacktrace_unittest)
     add_test (NAME stacktrace COMMAND stacktrace_unittest)
+    set_tests_properties(stacktrace PROPERTIES TIMEOUT 30)
   endif (TARGET stacktrace_unittest)
 
   add_test (NAME stl_logging COMMAND stl_logging_unittest)

--- a/Dockerfile.ubuntu.template
+++ b/Dockerfile.ubuntu.template
@@ -1,0 +1,14 @@
+# Build Ubuntu image
+FROM @BUILD_ARCH@/@BUILD_FLAVOR@:@BUILD_RELEASE@
+
+# see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/run
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  @BUILD_PACKAGES@ \
+  build-essential \
+  g++
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app

--- a/README
+++ b/README
@@ -1,5 +1,0 @@
-This repository contains a C++ implementation of the Google logging
-module.  Documentation for the implementation is in doc/.
-
-See INSTALL for (generic) installation instructions for C++: basically
-   ./autogen.sh && ./configure && make && make install

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+[![Build Status](https://img.shields.io/travis/google/glog/master.svg?label=Travis)](https://travis-ci.org/google/glog/builds)
+[![Grunt status](https://img.shields.io/appveyor/ci/google/glog/master.svg?label=Appveyor)](https://ci.appveyor.com/project/google/glog/history)
+
+This repository contains a C++ implementation of the Google logging
+module.  Documentation for the implementation is in doc/.
+
+See INSTALL for (generic) installation instructions for C++: basically
+```sh
+./autogen.sh && ./configure && make && make install
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,71 @@
+# global environment variables
+environment:
+  global:
+    # path to source directory of project to be built
+    PROJECT_DIR: .
+    # output test results for failing tests
+    CTEST_OUTPUT_ON_FAILURE: 1
+
+  # test matrix
+  matrix:
+
+    - TOOLCHAIN: "vs-14-2015-sdk-8-1"
+      GENERATOR: "Visual Studio 14 2015 Win64"
+      TEST_TARGET: RUN_TESTS
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - TOOLCHAIN: "vs-14-2015-win64"
+      GENERATOR: "Visual Studio 14 2015 Win64"
+      TEST_TARGET: RUN_TESTS
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - TOOLCHAIN: "vs-15-2017-win64"
+      GENERATOR: "Visual Studio 15 2017 Win64"
+      TEST_TARGET: RUN_TESTS
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - TOOLCHAIN: "vs-15-2017-win64-cxx17"
+      GENERATOR: "Visual Studio 15 2017 Win64"
+      TEST_TARGET: RUN_TESTS
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - TOOLCHAIN: "mingw-cxx11"
+      GENERATOR: "MinGW Makefiles"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin"
+      TEST_TARGET: test
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - TOOLCHAIN: "mingw-gnuxx11"
+      GENERATOR: "MinGW Makefiles"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin"
+      TEST_TARGET: test
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+    - TOOLCHAIN: "mingw-cxx17"
+      GENERATOR: "MinGW Makefiles"
+      MINGW_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin"
+      TEST_TARGET: test
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+
+install:
+  # Remove entry with sh.exe from PATH to fix error with MinGW toolchain
+  # (For MinGW make to work correctly sh.exe must NOT be in your path)
+  # * http://stackoverflow.com/a/3870338/2288008
+  - cmd: set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+
+  # set MINGW path
+  - cmd: IF DEFINED MINGW_PATH set PATH=%MINGW_PATH%;%PATH%
+
+  # Visual Studio 15 2017: Mimic behavior of older versions
+  - cmd: set VS150COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools
+
+build_script:
+  - cmd: cmake -H. -B_build_%TOOLCHAIN%_Debug -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE="%cd%\toolchains\%TOOLCHAIN%.cmake"
+  - cmd: cmake --build _build_%TOOLCHAIN%_Debug --config Debug
+  #- cmd: cmake -H. -B_build_%TOOLCHAIN%_Release -G "%GENERATOR%" -DCMAKE_TOOLCHAIN_FILE="%cd%\toolchains\%TOOLCHAIN%.cmake"
+  #- cmd: cmake --build _build_%TOOLCHAIN%_Release --config Release
+  # add git back to PATH for `diff` command in case of error
+  - cmd: set PATH=C:\Program Files\Git\usr\bin;%PATH%
+  - cmd: IF DEFINED TEST_TARGET cmake --build _build_%TOOLCHAIN%_Debug --target %TEST_TARGET%
+  #- cmd: IF DEFINED TEST_TARGET cmake --build _build_%TOOLCHAIN%_Release --target %TEST_TARGET%
+

--- a/toolchains/.gitignore
+++ b/toolchains/.gitignore
@@ -1,0 +1,2 @@
+# allow toolchain files to be tracked by git
+!*.cmake

--- a/toolchains/gcc-cxx11.cmake
+++ b/toolchains/gcc-cxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/toolchains/gcc-cxx17.cmake
+++ b/toolchains/gcc-cxx17.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/toolchains/gcc-cxx98.cmake
+++ b/toolchains/gcc-cxx98.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/toolchains/gcc-gnuxx11.cmake
+++ b/toolchains/gcc-gnuxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/gcc.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)

--- a/toolchains/linux-mingw-w64-cxx11.cmake
+++ b/toolchains/linux-mingw-w64-cxx11.cmake
@@ -1,0 +1,33 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64`
+#    *) cmake -H. -B_build_mingw -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/linux-mingw-w64.cmake"
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# set compiler
+set(CMAKE_C_COMPILER   ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER  ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# use emulator for `try_run` calls
+set(CMAKE_CROSSCOMPILING_EMULATOR wine64)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/toolchains/linux-mingw-w64-cxx17.cmake
+++ b/toolchains/linux-mingw-w64-cxx17.cmake
@@ -1,0 +1,33 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64`
+#    *) cmake -H. -B_build_mingw -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/linux-mingw-w64.cmake"
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# set compiler
+set(CMAKE_C_COMPILER   ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER  ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# use emulator for `try_run` calls
+set(CMAKE_CROSSCOMPILING_EMULATOR wine64)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/toolchains/linux-mingw-w64-gnuxx11.cmake
+++ b/toolchains/linux-mingw-w64-gnuxx11.cmake
@@ -1,0 +1,33 @@
+# Sample toolchain file for building for Windows from an Ubuntu Linux system.
+#
+# Typical usage:
+#    *) install cross compiler: `sudo apt-get install mingw-w64`
+#    *) cmake -H. -B_build_mingw -DCMAKE_TOOLCHAIN_FILE="${PWD}/toolchains/linux-mingw-w64.cmake"
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+set(TOOLCHAIN_PREFIX x86_64-w64-mingw32)
+
+# set compiler
+set(CMAKE_C_COMPILER   ${TOOLCHAIN_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}-g++)
+set(CMAKE_RC_COMPILER  ${TOOLCHAIN_PREFIX}-windres)
+
+# target environment on the build host system
+#   set 1st to dir with the cross compiler's C/C++ headers/libs
+set(CMAKE_FIND_ROOT_PATH /usr/${TOOLCHAIN_PREFIX})
+
+# modify default behavior of FIND_XXX() commands to
+# search for headers/libs in the target environment and
+# search for programs in the build host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+
+# use emulator for `try_run` calls
+set(CMAKE_CROSSCOMPILING_EMULATOR wine64)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)

--- a/toolchains/mingw-cxx11.cmake
+++ b/toolchains/mingw-cxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="%cd%\toolchains\mingw.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/toolchains/mingw-cxx17.cmake
+++ b/toolchains/mingw-cxx17.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="%cd%\toolchains\mingw.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/toolchains/mingw-gnuxx11.cmake
+++ b/toolchains/mingw-gnuxx11.cmake
@@ -1,0 +1,13 @@
+# Sample toolchain file for building with gcc compiler
+#
+# Typical usage:
+#    *) cmake -H. -B_build -DCMAKE_TOOLCHAIN_FILE="%cd%\toolchains\mingw.cmake"
+
+# set compiler
+set(CMAKE_C_COMPILER gcc)
+set(CMAKE_CXX_COMPILER g++)
+
+# set c++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS YES)

--- a/toolchains/vs-14-2015-sdk-8-1.cmake
+++ b/toolchains/vs-14-2015-sdk-8-1.cmake
@@ -1,0 +1,2 @@
+# set c++ standard
+set(CMAKE_SYSTEM_VERSION 8.1)

--- a/toolchains/vs-14-2015-win64.cmake
+++ b/toolchains/vs-14-2015-win64.cmake
@@ -1,0 +1,1 @@
+# dummy, nothing extra to set

--- a/toolchains/vs-15-2017-win64-cxx17.cmake
+++ b/toolchains/vs-15-2017-win64-cxx17.cmake
@@ -1,0 +1,2 @@
+# set c++ standard
+set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} /std:c++17")

--- a/toolchains/vs-15-2017-win64.cmake
+++ b/toolchains/vs-15-2017-win64.cmake
@@ -1,0 +1,1 @@
+# dummy, nothing extra to set


### PR DESCRIPTION
My attempt to use the services Appveyor and Travis to enable Continuous Integration for Glog

Add toolchain directory with cmake toolchain files used to find
compilers and set C++ versions

The following configurations are build on Windows using appveyor
service:
- enable MSVC 2015 SDK 8.1
- enable MSVC 2015
- enable MSVC 2017
- enable MSVC 2017 c++17
- enable mingw-cxx11
- enable mingw-gnuxx11
- enable mingw-cxx17

The following configurations are build on Linux using travis service:
- enable Ubuntu 14.04 amd64/i386, C++11
- enable Ubuntu 16.04 amd64/i386, C++11
- enable Ubuntu 18.04 amd64 C++98, C++11, GNU++11, C++17
- enable mingw-w64 on Ubuntu 18.04 amd64, C++11, GNU++11, C++17

The tests for cross compiled mingw windows binaries are run using wine64