### PR TITLE
Fix windows logging ut

### DIFF
--- a/src/googletest.h
+++ b/src/googletest.h
@@ -90,6 +90,8 @@ static const char TEST_SRC_DIR[] = "../..";
 static const char TEST_SRC_DIR[] = ".";
 #endif
 
+static const uint32_t PTR_TEST_VALUE = 0x12345678;
+
 DEFINE_string(test_tmpdir, GetTempDir(), "Dir we use for temp files");
 DEFINE_string(test_srcdir, TEST_SRC_DIR,
               "Source-dir root, needed to find glog_unittest_flagfile");
@@ -447,10 +449,12 @@ static inline string Munge(const string& filename) {
   while (fgets(buf, 4095, fp)) {
     string line = MungeLine(buf);
     char null_str[256];
+    char ptr_str[256];
     sprintf(null_str, "%p", static_cast<void*>(NULL));
+    sprintf(ptr_str, "%p", reinterpret_cast<void*>(PTR_TEST_VALUE));
+
     StringReplace(&line, "__NULLP__", null_str);
-    // Remove 0x prefix produced by %p. VC++ doesn't put the prefix.
-    StringReplace(&line, " 0x", " ");
+    StringReplace(&line, "__PTRTEST__", ptr_str);
 
     StringReplace(&line, "__SUCCESS__", StrError(0));
     StringReplace(&line, "__ENOENT__", StrError(ENOENT));

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -489,7 +489,11 @@ static inline bool MungeAndDiffTestStderr(const string& golden_filename) {
     WriteToFile(golden, munged_golden);
     string munged_captured = cap->filename() + ".munged";
     WriteToFile(captured, munged_captured);
+#ifdef OS_WINDOWS
+    string diffcmd("fc " + munged_golden + " " + munged_captured);
+#else
     string diffcmd("diff -u " + munged_golden + " " + munged_captured);
+#endif
     if (system(diffcmd.c_str()) != 0) {
       fprintf(stderr, "diff command was failed.\n");
     }

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -323,7 +323,7 @@ void TestRawLogging() {
   RAW_LOG(WARNING, "%s", s);
   const char const_s[] = "const array";
   RAW_LOG(INFO, "%s", const_s);
-  void* p = reinterpret_cast<void*>(0x12345678);
+  void* p = reinterpret_cast<void*>(PTR_TEST_VALUE);
   RAW_LOG(INFO, "ptr %p", p);
   p = NULL;
   RAW_LOG(INFO, "ptr %p", p);

--- a/src/logging_unittest.err
+++ b/src/logging_unittest.err
@@ -80,7 +80,7 @@ no prefix
 IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo bar 10 3.400000
 WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: array
 IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: const array
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: ptr 0x12345678
+IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: ptr __PTRTEST__
 IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: ptr __NULLP__
 EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo 1000 0000001000 3e8
 IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo 1000

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -70,8 +70,11 @@
  * 4715: for some reason VC++ stopped realizing you can't return after abort()
  * 4800: we know we're casting ints/char*'s to bools, and we're ok with that
  * 4996: Yes, we're ok using "unsafe" functions like fopen() and strerror()
+ * 4312: Converting uint32_t to a pointer when testing %p
+ * 4267: also subtracting two size_t to int
+ * 4722: Destructor never returns due to abort()
  */
-#pragma warning(disable:4244 4251 4355 4715 4800 4996)
+#pragma warning(disable:4244 4251 4355 4715 4800 4996 4267 4312 4722)
 
 /* file I/O */
 #define PATH_MAX 1024
@@ -86,6 +89,11 @@
 #define pclose  _pclose
 #define R_OK    04           /* read-only (for access()) */
 #define S_ISDIR(m)  (((m) & _S_IFMT) == _S_IFDIR)
+
+#define O_WRONLY _O_WRONLY
+#define O_CREAT _O_CREAT
+#define O_EXCL _O_EXCL
+
 #ifndef __MINGW32__
 enum { STDIN_FILENO = 0, STDOUT_FILENO = 1, STDERR_FILENO = 2 };
 #endif


### PR DESCRIPTION
this is the commits from PR https://github.com/google/glog/pull/93 from @artemdinaburg rebased on the current master. @artemdinaburg already signed the CLA, hope this is ok

these changes fixes the logging unittest on Windows (MSVC and MinGW)

Using CI from #330
Appveyor: https://ci.appveyor.com/project/NeroBurner/glog/build/1.0.100
Travis: https://travis-ci.org/NeroBurner/glog/builds/394146261