### PR TITLE
tests: fix compilation with C++17

### DIFF
--- a/src/googletest.h
+++ b/src/googletest.h
@@ -578,21 +578,21 @@ void (*g_new_hook)() = NULL;
 
 _END_GOOGLE_NAMESPACE_
 
-void* operator new(size_t size) throw(std::bad_alloc) {
+void* operator new(size_t size) {
   if (GOOGLE_NAMESPACE::g_new_hook) {
     GOOGLE_NAMESPACE::g_new_hook();
   }
   return malloc(size);
 }
 
-void* operator new[](size_t size) throw(std::bad_alloc) {
+void* operator new[](size_t size) {
   return ::operator new(size);
 }
 
-void operator delete(void* p) throw() {
+void operator delete(void* p) {
   free(p);
 }
 
-void operator delete[](void* p) throw() {
+void operator delete[](void* p) {
   ::operator delete(p);
 }


### PR DESCRIPTION
Remove throw() commands as they were deprecated with C++11 and are removed with C++17

Fast fix for https://github.com/google/glog/issues/329

CI with this C++17 fix AND windows logging fix https://github.com/google/glog/pull/331
- Appveyor: https://ci.appveyor.com/project/NeroBurner/glog/build/1.0.105
- Travis: https://travis-ci.org/NeroBurner/glog/builds/394986450?utm_source=github_status&utm_medium=notification