### PR TITLE
Adds CHECK support for nullptr. (fixes #341)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,6 +26,7 @@ Abhishek Dasgupta <abhi2743@gmail.com>
 Abhishek Parmar <abhishek@orng.net>
 Andrew Schwartzmeyer <andrew@schwartzmeyer.com>
 Andy Ying <andy@trailofbits.com>
+Bret McKee <bretmckee@google.com>
 Brian Silverman <bsilver16384@gmail.com>
 Fumitoshi Ukai <ukai@google.com>
 Guillaume Dumont <dumont.guillaume@gmail.com>

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -649,6 +649,10 @@ void MakeCheckOpValueString(std::ostream* os, const signed char& v);
 template <> GOOGLE_GLOG_DLL_DECL
 void MakeCheckOpValueString(std::ostream* os, const unsigned char& v);
 
+// Provide printable value for nullptr_t
+template <> GOOGLE_GLOG_DLL_DECL
+void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& v);
+
 // Build the error message string. Specify no inlining for code size.
 template <typename T1, typename T2>
 std::string* MakeCheckOpString(const T1& v1, const T2& v2, const char* exprtext)

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -649,9 +649,12 @@ void MakeCheckOpValueString(std::ostream* os, const signed char& v);
 template <> GOOGLE_GLOG_DLL_DECL
 void MakeCheckOpValueString(std::ostream* os, const unsigned char& v);
 
+// This is required because nullptr is only present in c++ 11 and later.
+#if __cplusplus >= 201103L
 // Provide printable value for nullptr_t
 template <> GOOGLE_GLOG_DLL_DECL
 void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& v);
+#endif
 
 // Build the error message string. Specify no inlining for code size.
 template <typename T1, typename T2>

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -2163,6 +2163,11 @@ void MakeCheckOpValueString(std::ostream* os, const unsigned char& v) {
   }
 }
 
+template <>
+void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& v) {
+  (*os) << "nullptr";
+}
+
 void InitGoogleLogging(const char* argv0) {
   glog_internal_namespace_::InitGoogleLoggingUtilities(argv0);
 }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -2163,10 +2163,12 @@ void MakeCheckOpValueString(std::ostream* os, const unsigned char& v) {
   }
 }
 
+#if __cplusplus >= 201103L
 template <>
 void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& v) {
   (*os) << "nullptr";
 }
+#endif
 
 void InitGoogleLogging(const char* argv0) {
   glog_internal_namespace_::InitGoogleLoggingUtilities(argv0);


### PR DESCRIPTION
This allows CHECK_NE(foo, nullptr) to compile and produces "nullptr" for the
string representation of nullptr.