### PR TITLE
Fix errors with BUILD_SHARED_LIBS=ON for Visual Studio 2017.

### DIFF
--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -156,7 +156,7 @@ enum { PTHREAD_ONCE_INIT = 0 };   // important that this be 0! for SpinLock
 #endif // HAVE_PTHREAD
 
 #ifndef HAVE_LOCALTIME_R
-extern struct tm* GOOGLE_GLOG_DLL_DECL localtime_r(const time_t* timep, struct tm* result);
+extern GOOGLE_GLOG_DLL_DECL struct tm* localtime_r(const time_t* timep, struct tm* result);
 #endif // not HAVE_LOCALTIME_R
 
 inline char* strerror_r(int errnum, char* buf, size_t buflen) {


### PR DESCRIPTION
Fixes #343.