### PR TITLE
Fix stacktrace on Bazel build.

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -73,7 +73,16 @@ def glog_library(namespace='google', with_gflags=1, **kwargs):
 
             # Include generated header files.
             '-I%s/glog_internal' % gendir,
-        ] + ([
+        ] + select({
+            # For stacktrace.
+            '@bazel_tools//src/conditions:darwin': [
+                '-DHAVE_UNWIND_H',
+                '-DHAVE_DLADDR',
+            ],
+            '//conditions:default': [
+                '-DHAVE_UNWIND_H',
+            ],
+        }) + ([
             # Use gflags to parse CLI arguments.
             '-DHAVE_LIB_GFLAGS',
         ] if with_gflags else []),


### PR DESCRIPTION
We need at least following defs to be set to print stacktrace in
failure signal handler.

- HAVE_UNWIND_H: On Linux and macOS. unwind.h is usually present
  by default on those systems.
- HAVE_DLADDR: On macOS.

Note that today glog does not build with Bazel on Windows.

Resolves #346.