### PR TITLE
Allow getpwuid_r to return missing entry.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,6 +31,7 @@ Fumitoshi Ukai <ukai@google.com>
 Guillaume Dumont <dumont.guillaume@gmail.com>
 Håkan L. S. Younes <hyounes@google.com>
 Ivan Penkov <ivanpe@google.com>
+Jacob Trimble <modmaker@google.com>
 Jim Ray <jimray@google.com>
 Michael Tanner <michael@tannertaxpro.com>
 MiniLight <MiniLightAR@Gmail.com>

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -311,7 +311,7 @@ static void MyUserNameInitializer() {
     char buffer[1024] = {'\0'};
     uid_t uid = geteuid();
     int pwuid_res = getpwuid_r(uid, &pwd, buffer, sizeof(buffer), &result);
-    if (pwuid_res == 0) {
+    if (pwuid_res == 0 && result) {
       g_my_user_name = pwd.pw_name;
     } else {
       snprintf(buffer, sizeof(buffer), "uid%d", uid);


### PR DESCRIPTION
If the getpwuid_r method doesn't find an entry with the given ID, it will still return success (0), but the *result will be set to NULL. This checks the `result` value so it won't crash if it doesn't find the entry.

This normally shouldn't ever happen (since it just got the value from `geteuid()`), but it can somehow happen on iOS simulators.