### PR TITLE
Fix warnings

### DIFF
--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -1075,13 +1075,14 @@ TEST(Strerror, logging) {
 
 // Simple routines to look at the sizes of generated code for LOG(FATAL) and
 // CHECK(..) via objdump
+/*
 static void MyFatal() {
   LOG(FATAL) << "Failed";
 }
 static void MyCheck(bool a, bool b) {
   CHECK_EQ(a, b);
 }
-
+*/
 #ifdef HAVE_LIB_GMOCK
 
 TEST(DVLog, Basic) {


### PR DESCRIPTION
Fixed these warnings:

```
src/logging_unittest.cc: At global scope:
src/logging_unittest.cc:1081:13: warning: 'void MyCheck(bool, bool)' defined but not used [-Wunused-function]
 static void MyCheck(bool a, bool b) {
             ^~~~~~~
src/logging_unittest.cc:1078:13: warning: 'void MyFatal()' defined but not used [-Wunused-function]
 static void MyFatal() {
             ^~~~~~~
```