### PR TITLE
remove time from raw logging

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1249,7 +1249,6 @@ void LogMessage::Init(const char* file,
   data_->timestamp_ = static_cast<time_t>(now);
   localtime_r(&data_->timestamp_, &data_->tm_time_);
   int usecs = static_cast<int>((now - data_->timestamp_) * 1000000);
-  RawLog__SetLastTime(data_->tm_time_, usecs);
 
   data_->num_chars_to_log_ = 0;
   data_->num_chars_to_syslog_ = 0;


### PR DESCRIPTION
Fix for issue #212.

Thread sanitizer, mandatory in our ci process, refuses to accept glog because of this issue...

As the discussion in issue #212 indicated that google has already removed time from raw logging because of the same issue, I did the same. Instead, we log zeros (to keep the format the same as the normal logger).