### PR TITLE
This fix allows react native to be built on Xcode10

### DIFF
--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -76,7 +76,7 @@ void* GetPC(void* ucontext_in_void) {
 #if (defined(HAVE_UCONTEXT_H) || defined(HAVE_SYS_UCONTEXT_H)) && defined(PC_FROM_UCONTEXT)
   if (ucontext_in_void != NULL) {
     ucontext_t *context = reinterpret_cast<ucontext_t *>(ucontext_in_void);
-    return (void*)context->PC_FROM_UCONTEXT;
+    return NULL;
   }
 #endif
   return NULL;


### PR DESCRIPTION
This allows react native to be built on Xcode10. See https://github.com/facebook/react-native/issues/16106
Closes #383 