### PR TITLE
Upstream Chromium local changes to symbolize.cc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ option (WITH_GFLAGS "Use gflags" ON)
 option (WITH_THREADS "Enable multithreading support" ON)
 option (WITH_TLS "Enable Thread Local Storage (TLS) support" ON)
 option (BUILD_SHARED_LIBS "Build shared libraries" OFF)
+option (PRINT_UNSYMBOLIZED_STACK_TRACES
+  "Print raw pc values on symbolization failure" OFF)
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,15 @@ AC_PC_FROM_UCONTEXT(AC_MSG_WARN(Could not find the PC.  Will not output failed a
 
 AC_DEFINE_UNQUOTED(TEST_SRC_DIR, "$srcdir", [location of source code])
 
+AC_ARG_ENABLE(unsymbolized-traces,
+              AS_HELP_STRING([--enable-unsymbolized-traces],
+                             [Print raw pc values when symbolization is failed.]),
+              enable_unsymbolized_traces=yes)
+if test x"$enable_unsymbolized_traces" = x"yes"; then
+  AC_DEFINE(PRINT_UNSYMBOLIZED_STACK_TRACES, 1,
+            [define if we should print raw pc values on symbolization failure.])
+fi
+
 # These are what's needed by logging.h.in and raw_logging.h.in
 AC_SUBST(ac_google_start_namespace)
 AC_SUBST(ac_google_end_namespace)

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -167,6 +167,9 @@
 /* How to access the PC from a struct ucontext */
 #cmakedefine PC_FROM_UCONTEXT
 
+/* define if we should print raw pc values on symbolization failure. */
+#cmakedefine PRINT_UNSYMBOLIZED_STACK_TRACES
+
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */
 #cmakedefine PTHREAD_CREATE_JOINABLE

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -154,6 +154,9 @@
 /* How to access the PC from a struct ucontext */
 #undef PC_FROM_UCONTEXT
 
+/* define if we should print raw pc values on symbolization failure. */
+#undef PRINT_UNSYMBOLIZED_STACK_TRACES
+
 /* Define to necessary symbol if this constant uses a non-standard name on
    your system. */
 #undef PTHREAD_CREATE_JOINABLE

--- a/src/symbolize.h
+++ b/src/symbolize.h
@@ -116,8 +116,11 @@ _START_GOOGLE_NAMESPACE_
 // counter "pc". The callback function should write output to "out"
 // and return the size of the output written. On error, the callback
 // function should return -1.
-typedef int (*SymbolizeCallback)(int fd, void *pc, char *out, size_t out_size,
-                                 uint64 relocation);
+typedef int (*SymbolizeCallback)(int fd,
+                                 void* pc,
+                                 char* out,
+                                 size_t out_size,
+                                 uint64_t relocation);
 void InstallSymbolizeCallback(SymbolizeCallback callback);
 
 // Installs a callback function, which will be called instead of
@@ -130,10 +133,10 @@ void InstallSymbolizeCallback(SymbolizeCallback callback);
 // file is opened successfully, returns the file descriptor.  Otherwise,
 // returns -1.  |out_file_name_size| is the size of the file name buffer
 // (including the null-terminator).
-typedef int (*SymbolizeOpenObjectFileCallback)(uint64 pc,
-                                               uint64 &start_address,
-                                               uint64 &base_address,
-                                               char *out_file_name,
+typedef int (*SymbolizeOpenObjectFileCallback)(uint64_t pc,
+                                               uint64_t& start_address,
+                                               uint64_t& base_address,
+                                               char* out_file_name,
                                                int out_file_name_size);
 void InstallSymbolizeOpenObjectFileCallback(
     SymbolizeOpenObjectFileCallback callback);


### PR DESCRIPTION
Chromium has its own fork of symbolize.cc and symbolize.h, and it has
several not-yet-upstreamed changes, that are not specific to Chromium.

This patch upstreams such a changes.

  Fixed google::FindSymbol reading past end of a section
  https://chromium.googlesource.com/chromium/src/+/3dae0a2d7da309159a301e40a592692ec8431a38

  Fix -INT_MIN integer overflow in itoa_r().
  https://chromium.googlesource.com/chromium/src/+/ac4d28e9cb934e01ff16a9e67a5f387caa82719f

  Add print_unsymbolized_stack_traces gn arg.
  https://chromium.googlesource.com/chromium/src/+/6a2726776f59cdcf0090f584a15db4a1ab8c40d7

  Switch to standard integer types in base/.
  https://chromium.googlesource.com/chromium/src/+/9b6f42934e5a1e65ebfc668d91a28a6e2678a14c