### PR TITLE
Fix logmailer problem for dynamic lib use of glog.

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -156,7 +156,7 @@ GLOG_DEFINE_int32(logemaillevel, 999,
                   "Email log messages logged at this level or higher"
                   " (0 means email all; 3 means email FATAL only;"
                   " ...)");
-GLOG_DEFINE_string(logmailer, "/bin/mail",
+GLOG_DEFINE_string(logmailer, "",
                    "Mailer used to send logging email");
 
 // Compute the default value for --log_dir
@@ -2028,8 +2028,12 @@ static bool SendEmailInternal(const char*dest, const char *subject,
               subject, body, dest);
     }
 
+    string logmailer = FLAGS_logmailer;
+    if (logmailer.empty()) {
+        logmailer = "/bin/mail";
+    }
     string cmd =
-        FLAGS_logmailer + " -s" +
+        logmailer + " -s" +
         ShellEscape(subject) + " " + ShellEscape(dest);
     VLOG(4) << "Mailing command: " << cmd;
 


### PR DESCRIPTION
# The problem I met.
I want to use glog in a dynamic lib (.so file), e.g. use it with Apache/Arrow. 
However, if there is a global variable defined in non-empty `std::string`, there will be memory problems. I can catch this problem by valgrind. The following picture is the valgrind log.
![image](https://user-images.githubusercontent.com/19584326/49565272-9ca4f380-f961-11e8-9668-91aae53098f8.png)
# PR change
I have changed the default value of `logmailer` to an empty `std::string` and put the default value to where `FLAGS_logmailer` is used when it is empty.