### PR TITLE
automake: relax GNU standard directory style

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -72,7 +72,7 @@ Basic Installation
 
 Briefly, the shell commands `./configure; make; make install' should
 configure, build, and install this package.  The following
-more-detailed instructions are generic; see the `README' file for
+more-detailed instructions are generic; see the `README.md' file for
 instructions specific to this package.
 
    The `configure' shell script attempts to guess correct values for
@@ -92,7 +92,7 @@ cache files.
 
    If you need to do unusual things to compile the package, please try
 to figure out how `configure' could check whether to do them, and mail
-diffs or instructions to the address given in the `README' so they can
+diffs or instructions to the address given in the `README.md' so they can
 be considered for the next release.  If you are using the cache, and at
 some point `config.cache' contains results you don't want to keep, you
 may remove or edit it.
@@ -190,7 +190,7 @@ Some packages pay attention to `--enable-FEATURE' options to
 `configure', where FEATURE indicates an optional part of the package.
 They may also pay attention to `--with-PACKAGE' options, where PACKAGE
 is something like `gnu-as' or `x' (for the X Window System).  The
-`README' should mention any `--enable-' and `--with-' options that the
+`README.md' should mention any `--enable-' and `--with-' options that the
 package recognizes.
 
    For packages that use the X Window System, `configure' can usually

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
-AUTOMAKE_OPTIONS=subdir-objects
+AUTOMAKE_OPTIONS = subdir-objects foreign
 
 # Make sure that when we re-make ./configure, we get the macros we need
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_PREREQ(2.57)
 AC_INIT(glog, 0.3.5, opensource@google.com)
 # The argument here is just something that should be in the current directory
 # (for sanity checking)
-AC_CONFIG_SRCDIR(README)
+AC_CONFIG_SRCDIR(README.md)
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE
 AM_CONFIG_HEADER(src/config.h)

--- a/packages/deb/docs
+++ b/packages/deb/docs
@@ -3,6 +3,6 @@ COPYING
 ChangeLog
 INSTALL
 NEWS
-README
+README.md
 doc/designstyle.css
 doc/glog.html

--- a/packages/rpm/rpm.spec
+++ b/packages/rpm/rpm.spec
@@ -55,7 +55,7 @@ rm -rf $RPM_BUILD_ROOT
 ## documentation.  This depends on the following two lines appearing in
 ## Makefile.am:
 ##     docdir = $(prefix)/share/doc/$(PACKAGE)-$(VERSION)
-##     dist_doc_DATA = AUTHORS COPYING ChangeLog INSTALL NEWS README
+##     dist_doc_DATA = AUTHORS COPYING ChangeLog INSTALL NEWS README.md
 %docdir %{prefix}/share/doc/%{NAME}-%{VERSION}
 %{prefix}/share/doc/%{NAME}-%{VERSION}/*
 


### PR DESCRIPTION
GNU standard assumes `README` under root dir, while PR #403
didn't fix the building issue exactually.
https://www.gnu.org/software/automake/manual/html_node/List-of-Automake-options.html