### PR TITLE
Fix bazel build with gflags

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -94,18 +94,18 @@ sed -e 's/@ac_cv_cxx_using_operator@/1/g' \
     -e 's/@ac_cv_have_unistd_h@/1/g' \
     -e 's/@ac_cv_have_stdint_h@/1/g' \
     -e 's/@ac_cv_have_systypes_h@/1/g' \
-    -e 's/@ac_cv_have_libgflags_h@/1/g' \
+    -e 's/@ac_cv_have_libgflags@/{}/g' \
     -e 's/@ac_cv_have_uint16_t@/1/g' \
     -e 's/@ac_cv_have___builtin_expect@/1/g' \
     -e 's/@ac_cv_have_.*@/0/g' \
-    -e 's/@ac_google_start_namespace@/namespace google {/g' \
-    -e 's/@ac_google_end_namespace@/}/g' \
+    -e 's/@ac_google_start_namespace@/namespace google {{/g' \
+    -e 's/@ac_google_end_namespace@/}}/g' \
     -e 's/@ac_google_namespace@/google/g' \
     -e 's/@ac_cv___attribute___noinline@/__attribute__((noinline))/g' \
     -e 's/@ac_cv___attribute___noreturn@/__attribute__((noreturn))/g' \
     -e 's/@ac_cv___attribute___printf_4_5@/__attribute__((__format__ (__printf__, 4, 5)))/g'
 EOF
-''',
+'''.format(int(with_gflags)),
     )
 
     native.genrule(

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -7,7 +7,7 @@
 #       https://github.com/google/glog/issues/61
 #       https://github.com/google/glog/files/393474/BUILD.txt
 
-def glog_library(namespace='google', with_gflags=1):
+def glog_library(namespace='google', with_gflags=1, **kwargs):
     if native.repository_name() != '@':
         gendir = '$(GENDIR)/external/' + native.repository_name().lstrip('@')
     else:
@@ -80,6 +80,7 @@ def glog_library(namespace='google', with_gflags=1):
         deps = [
             '@com_github_gflags_gflags//:gflags',
         ] if with_gflags else [],
+        **kwargs
     )
 
     native.genrule(


### PR DESCRIPTION
The code references `@ac_cv_have_libgflags@` but not `@ac_cv_have_libgflags_h@`. This corrects that.

`int(with_gflags)` incorporates the possibility of `True/False`: https://github.com/bazelbuild/bazel/issues/4792