### PR TITLE
Fix demangling template parameter packs

### DIFF
--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -1097,10 +1097,11 @@ static bool ParseTemplateArgs(State *state) {
 // <template-arg>  ::= <type>
 //                 ::= <expr-primary>
 //                 ::= I <template-arg>* E        # argument pack
+//                 ::= J <template-arg>* E        # argument pack
 //                 ::= X <expression> E
 static bool ParseTemplateArg(State *state) {
   State copy = *state;
-  if (ParseOneCharToken(state, 'I') &&
+  if ((ParseOneCharToken(state, 'I') || ParseOneCharToken(state, 'J')) &&
       ZeroOrMore(ParseTemplateArg, state) &&
       ParseOneCharToken(state, 'E')) {
     return true;

--- a/src/demangle_unittest.cc
+++ b/src/demangle_unittest.cc
@@ -142,6 +142,12 @@ TEST(Demangle, FromFile) {
   }
 }
 
+// Template argument packs can start with I or J.
+TEST(Demangle, TemplateArgs) {
+  EXPECT_STREQ("add<>()", DemangleIt("_Z3addIIiEEvDpT_"));
+  EXPECT_STREQ("add<>()", DemangleIt("_Z3addIJiEEvDpT_"));
+}
+
 #endif
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Clang 4.0.1-10 and gcc 7.3.0 both mangle the function "void add<int>(int)" as
"_Z3addIJiEEvDpT_".  The template parameter pack is of the form
J <template-arg>* E

The opening character for a param pack could be either I or J, as libiberty
follows [1].  This change simply adds the J case.

[1] https://github.com/gcc-mirror/gcc/blob/fbd263526ad105a953fd51d9f7bca2c3f268cf82/libiberty/cp-demangle.c#L3209