### PR TITLE
Add demangle support for ABI tags.

### DIFF
--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -597,12 +597,12 @@ static bool ParsePrefix(State *state) {
 // <unqualified-name> ::= <operator-name>
 //                    ::= <ctor-dtor-name>
 //                    ::= <source-name> [<abi-tags>]
-//                    ::= <local-source-name>
+//                    ::= <local-source-name> [<abi-tags>]
 static bool ParseUnqualifiedName(State *state) {
   return (ParseOperatorName(state) ||
           ParseCtorDtorName(state) ||
           (ParseSourceName(state) && Optional(ParseAbiTags(state))) ||
-          ParseLocalSourceName(state));
+          (ParseLocalSourceName(state) && Optional(ParseAbiTags(state))));
 }
 
 // <source-name> ::= <positive length number> <identifier>

--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -30,7 +30,7 @@
 // Author: Satoru Takabayashi
 //
 // For reference check out:
-// http://www.codesourcery.com/public/cxx-abi/abi.html#mangling
+// http://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling
 //
 // Note that we only have partial C++0x support yet.
 
@@ -423,6 +423,8 @@ static bool ParseNumber(State *state, int *number_out);
 static bool ParseFloatNumber(State *state);
 static bool ParseSeqId(State *state);
 static bool ParseIdentifier(State *state, int length);
+static bool ParseAbiTags(State *state);
+static bool ParseAbiTag(State *state);
 static bool ParseOperatorName(State *state);
 static bool ParseSpecialName(State *state);
 static bool ParseCallOffset(State *state);
@@ -594,12 +596,12 @@ static bool ParsePrefix(State *state) {
 
 // <unqualified-name> ::= <operator-name>
 //                    ::= <ctor-dtor-name>
-//                    ::= <source-name>
+//                    ::= <source-name> [<abi-tags>]
 //                    ::= <local-source-name>
 static bool ParseUnqualifiedName(State *state) {
   return (ParseOperatorName(state) ||
           ParseCtorDtorName(state) ||
-          ParseSourceName(state) ||
+          (ParseSourceName(state) && Optional(ParseAbiTags(state))) ||
           ParseLocalSourceName(state));
 }
 
@@ -701,6 +703,23 @@ static bool ParseIdentifier(State *state, int length) {
   }
   state->mangled_cur += length;
   return true;
+}
+
+// <abi-tags> ::= <abi-tag> [<abi-tags>]
+static bool ParseAbiTags(State *state) {
+  State copy = *state;
+  DisableAppend(state);
+  if (OneOrMore(ParseAbiTag, state)) {
+    RestoreAppend(state, copy.append);
+    return true;
+  }
+  *state = copy;
+  return false;
+}
+
+// <abi-tag> ::= B <source-name>
+static bool ParseAbiTag(State *state) {
+  return ParseOneCharToken(state, 'B') && ParseSourceName(state);
 }
 
 // <operator-name> ::= nw, and other two letters cases

--- a/src/demangle_unittest.txt
+++ b/src/demangle_unittest.txt
@@ -45,6 +45,7 @@ _ZlsI3fooE	operator<< <>
 
 # ABI tags.
 _Z1AB3barB3foo	A
+_ZN3fooL3barB5cxx11E	foo::bar
 
 # Random things we found interesting.
 _ZN3FooISt6vectorISsSaISsEEEclEv	Foo<>::operator()()

--- a/src/demangle_unittest.txt
+++ b/src/demangle_unittest.txt
@@ -43,6 +43,9 @@ _ZNcvT_IiEEv	operator ?<>()
 # "<< <" case.
 _ZlsI3fooE	operator<< <>
 
+# ABI tags.
+_Z1AB3barB3foo	A
+
 # Random things we found interesting.
 _ZN3FooISt6vectorISsSaISsEEEclEv	Foo<>::operator()()
 _ZTI9Callback1IiE	Callback1<>


### PR DESCRIPTION
This should fix issue #50.

Also updates the reference URL, as the current one gives a 404 error.