### PR TITLE
Use push/pop macro when supressing warning

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1147,14 +1147,9 @@ public:
   // 2005 if you are deriving from a type in the Standard C++ Library"
   // http://msdn.microsoft.com/en-us/library/3tdb471s(VS.80).aspx
   // Let's just ignore the warning.
-#ifdef _MSC_VER
-# pragma warning(push)
-# pragma warning(disable: 4275)
-#endif
+GLOG_MSVC_PUSH_DISABLE_WARNING(4275)
   class GOOGLE_GLOG_DLL_DECL LogStream : public std::ostream {
-#ifdef _MSC_VER
-# pragma warning(pop)
-#endif
+GLOG_MSVC_POP_WARNING()
   public:
     LogStream(char *buf, int len, int ctr)
         : std::ostream(NULL),


### PR DESCRIPTION
* Same as PR #397 , but for the `.in` file. Useful for some unusual cross-platform build environments (e.g. WSL).