### PR TITLE
Stop using auto_ptr

### DIFF
--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -572,9 +572,10 @@ void TestDCHECK() {
   DCHECK_GT(2, 1);
   DCHECK_LT(1, 2);
 
-  unique_ptr<int64> sptr(new int64);
-  int64* ptr = DCHECK_NOTNULL(sptr.get());
-  CHECK_EQ(ptr, sptr.get());
+  int64* orig_ptr = new int64;
+  int64* ptr = DCHECK_NOTNULL(orig_ptr);
+  CHECK_EQ(ptr, orig_ptr);
+  delete orig_ptr;
 }
 
 void TestSTREQ() {

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -572,7 +572,7 @@ void TestDCHECK() {
   DCHECK_GT(2, 1);
   DCHECK_LT(1, 2);
 
-  auto_ptr<int64> sptr(new int64);
+  unique_ptr<int64> sptr(new int64);
   int64* ptr = DCHECK_NOTNULL(sptr.get());
   CHECK_EQ(ptr, sptr.get());
 }


### PR DESCRIPTION
Saw an error in AppVeyor:

c:\projects\glog\src\logging_unittest.cc(575): error C2065: 'auto_ptr': undeclared identifier [C:\projects\glog\_build_vs-15-2017-win64-cxx17_Debug\logging_unittest.vcxproj]