### PR TITLE
 Protect macros from user code to the left of them

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Guillaume Dumont <dumont.guillaume@gmail.com>
 Michael Tanner <michael@tannertaxpro.com>
 MiniLight <MiniLightAR@Gmail.com>
 romange <romange@users.noreply.github.com>
+Roman Perepelitsa <roman.perepelitsa@gmail.com>
 Sergiu Deitsch <sergiu.deitsch@gmail.com>
 tbennun <tbennun@gmail.com>
 Teddy Reed <teddy@prosauce.org>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -37,6 +37,7 @@ MiniLight <MiniLightAR@Gmail.com>
 Peter Collingbourne <pcc@google.com>
 Rodrigo Queiro <rodrigoq@google.com>
 romange <romange@users.noreply.github.com>
+Roman Perepelitsa <roman.perepelitsa@gmail.com>
 Sergiu Deitsch <sergiu.deitsch@gmail.com>
 Shinichiro Hamaji <hamaji@google.com>
 tbennun <tbennun@gmail.com>

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -568,8 +568,10 @@ class LogSink;  // defined below
   LOG_TO_STRING_##severity(static_cast<std::vector<std::string>*>(outvec)).stream()
 
 #define LOG_IF(severity, condition) \
+  static_cast<void>(0),             \
   !(condition) ? (void) 0 : @ac_google_namespace@::LogMessageVoidify() & LOG(severity)
 #define SYSLOG_IF(severity, condition) \
+  static_cast<void>(0),                \
   !(condition) ? (void) 0 : @ac_google_namespace@::LogMessageVoidify() & SYSLOG(severity)
 
 #define LOG_ASSERT(condition)  \
@@ -859,6 +861,7 @@ DECLARE_CHECK_STROP_IMPL(strcasecmp, false)
       &@ac_google_namespace@::LogMessage::SendToLog)
 
 #define PLOG_IF(severity, condition) \
+  static_cast<void>(0),              \
   !(condition) ? (void) 0 : @ac_google_namespace@::LogMessageVoidify() & PLOG(severity)
 
 // A CHECK() macro that postpends errno if the condition is false. E.g.
@@ -1003,23 +1006,29 @@ const LogSeverity GLOG_0 = GLOG_ERROR;
 
 #else  // !DCHECK_IS_ON()
 
-#define DLOG(severity) \
+#define DLOG(severity)  \
+  static_cast<void>(0), \
   true ? (void) 0 : @ac_google_namespace@::LogMessageVoidify() & LOG(severity)
 
-#define DVLOG(verboselevel) \
-  (true || !VLOG_IS_ON(verboselevel)) ?\
-    (void) 0 : @ac_google_namespace@::LogMessageVoidify() & LOG(INFO)
+#define DVLOG(verboselevel)             \
+  static_cast<void>(0),                 \
+  (true || !VLOG_IS_ON(verboselevel)) ? \
+      (void) 0 : @ac_google_namespace@::LogMessageVoidify() & LOG(INFO)
 
 #define DLOG_IF(severity, condition) \
+  static_cast<void>(0),              \
   (true || !(condition)) ? (void) 0 : @ac_google_namespace@::LogMessageVoidify() & LOG(severity)
 
 #define DLOG_EVERY_N(severity, n) \
+  static_cast<void>(0),           \
   true ? (void) 0 : @ac_google_namespace@::LogMessageVoidify() & LOG(severity)
 
 #define DLOG_IF_EVERY_N(severity, condition, n) \
+  static_cast<void>(0),                         \
   (true || !(condition))? (void) 0 : @ac_google_namespace@::LogMessageVoidify() & LOG(severity)
 
 #define DLOG_ASSERT(condition) \
+  static_cast<void>(0),        \
   true ? (void) 0 : LOG_ASSERT(condition)
 
 // MSVC warning C4127: conditional expression is constant

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -572,8 +572,10 @@ class LogSink;  // defined below
   LOG_TO_STRING_##severity(static_cast<std::vector<std::string>*>(outvec)).stream()
 
 #define LOG_IF(severity, condition) \
+  static_cast<void>(0),             \
   !(condition) ? (void) 0 : google::LogMessageVoidify() & LOG(severity)
 #define SYSLOG_IF(severity, condition) \
+  static_cast<void>(0),                \
   !(condition) ? (void) 0 : google::LogMessageVoidify() & SYSLOG(severity)
 
 #define LOG_ASSERT(condition)  \
@@ -863,6 +865,7 @@ DECLARE_CHECK_STROP_IMPL(strcasecmp, false)
       &google::LogMessage::SendToLog)
 
 #define PLOG_IF(severity, condition) \
+  static_cast<void>(0),              \
   !(condition) ? (void) 0 : google::LogMessageVoidify() & PLOG(severity)
 
 // A CHECK() macro that postpends errno if the condition is false. E.g.
@@ -1006,23 +1009,29 @@ const LogSeverity GLOG_0 = GLOG_ERROR;
 
 #else  // !DCHECK_IS_ON()
 
-#define DLOG(severity) \
+#define DLOG(severity)  \
+  static_cast<void>(0), \
   true ? (void) 0 : google::LogMessageVoidify() & LOG(severity)
 
-#define DVLOG(verboselevel) \
-  (true || !VLOG_IS_ON(verboselevel)) ?\
+#define DVLOG(verboselevel)             \
+  static_cast<void>(0),                 \
+  (true || !VLOG_IS_ON(verboselevel)) ? \
     (void) 0 : google::LogMessageVoidify() & LOG(INFO)
 
 #define DLOG_IF(severity, condition) \
+  static_cast<void>(0),              \
   (true || !(condition)) ? (void) 0 : google::LogMessageVoidify() & LOG(severity)
 
 #define DLOG_EVERY_N(severity, n) \
+  static_cast<void>(0),           \
   true ? (void) 0 : google::LogMessageVoidify() & LOG(severity)
 
 #define DLOG_IF_EVERY_N(severity, condition, n) \
+  static_cast<void>(0),                         \
   (true || !(condition))? (void) 0 : google::LogMessageVoidify() & LOG(severity)
 
 #define DLOG_ASSERT(condition) \
+  static_cast<void>(0),        \
   true ? (void) 0 : LOG_ASSERT(condition)
 
 // MSVC warning C4127: conditional expression is constant


### PR DESCRIPTION
Currently the following code compiles (and the check passes):

```c++
!CHECK(2 + 2 == 5);
```

Such mistakes can happen by accident. They can be especially difficult to notice if the user code that interferes with the CHECK is on the previous line:

```c++
DoStuff(42);~

// Make sure the index is within bounds. Otherwise a malicious
// actor could execute arbitrary code on our machine.
CHECK(index < length);
```

Oops! The check always passes.

This PR causes this code to be rejected at compile time.