### PR TITLE
Add extra information in log file header (application build/version, actual duration time)

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -522,6 +522,8 @@ GOOGLE_GLOG_DLL_DECL void ShutdownGoogleLogging();
 // Install a function which will be called after LOG(FATAL).
 GOOGLE_GLOG_DLL_DECL void InstallFailureFunction(void (*fail_func)());
 
+GOOGLE_GLOG_DLL_DECL void SetApplicationFingerprint(const std::string& fingerprint);
+
 class LogSink;  // defined below
 
 // If a non-NULL sink pointer is given, we push this message to that sink.

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -437,6 +437,7 @@ class LogFileObject : public base::Logger {
   uint32 file_length_;
   unsigned int rollover_attempt_;
   int64 next_flush_time_;         // cycle count at which to flush log
+  WallTime start_time_;
 
   // Actually create a logfile using the value of base_filename_ and the
   // supplied argument time_pid_string
@@ -824,7 +825,24 @@ void LogDestination::DeleteLogDestinations() {
   sinks_ = NULL;
 }
 
+static string g_application_fingerprint;
+
+void SetApplicationFingerprint(const std::string& fingerprint) {
+  g_application_fingerprint = fingerprint;
+}
+
 namespace {
+
+string PrettyDuration(int secs) {
+  std::stringstream result;
+  int mins = secs / 60;
+  int hours = mins / 60;
+  mins = mins % 60;
+  secs = secs % 60;
+  result.fill('0');
+  result << hours << ':' << setw(2) << mins << ':' << setw(2) << secs;
+  return result.str();
+}
 
 LogFileObject::LogFileObject(LogSeverity severity,
                              const char* base_filename)
@@ -838,7 +856,8 @@ LogFileObject::LogFileObject(LogSeverity severity,
     dropped_mem_length_(0),
     file_length_(0),
     rollover_attempt_(kRolloverAttemptFrequency-1),
-    next_flush_time_(0) {
+    next_flush_time_(0),
+    start_time_(WallTime_Now()) {
   assert(severity >= 0);
   assert(severity < NUM_SEVERITIES);
 }
@@ -1072,7 +1091,14 @@ void LogFileObject::Write(bool force_flush,
                        << setw(2) << tm_time.tm_min << ':'
                        << setw(2) << tm_time.tm_sec << '\n'
                        << "Running on machine: "
-                       << LogDestination::hostname() << '\n'
+                       << LogDestination::hostname() << '\n';
+
+    if(!g_application_fingerprint.empty()) {
+      file_header_stream << "Application fingerprint: " << g_application_fingerprint << '\n';
+    }
+
+    file_header_stream << "Running duration (h:mm:ss): "
+                       << PrettyDuration(static_cast<int>(WallTime_Now() - start_time_)) << '\n'
                        << "Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu "
                        << "threadid file:line] msg" << '\n';
     const string& file_header_string = file_header_stream.str();


### PR DESCRIPTION
It is very useful to have application version/build specific information in log file. 
It is possible to write in on start, but in case of log file rolling this information will be lost. 
Also it is useful to know actual running time of application when customer sends you just last log file