### PR TITLE
Add extra information in log file header (application build/version, actual duration time)

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -529,7 +529,7 @@ GOOGLE_GLOG_DLL_DECL void InstallFailureFunction(void (*fail_func)());
 // Enable/Disable old log cleaner.
 GOOGLE_GLOG_DLL_DECL void EnableLogCleaner(int overdue_days);
 GOOGLE_GLOG_DLL_DECL void DisableLogCleaner();
-
+GOOGLE_GLOG_DLL_DECL void SetApplicationFingerprint(const std::string& fingerprint);
 
 class LogSink;  // defined below
 


### PR DESCRIPTION
It is very useful to have application version/build specific information in log file.
It is possible to write in on start, but in case of log file rolling this information will be lost.
Also it is useful to know actual running time of application when customer sends you just last log file