### PR TITLE
Fix symbolize_unittest for musl builds

### DIFF
--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -401,7 +401,7 @@ int main(int argc, char **argv) {
   FLAGS_logtostderr = true;
   InitGoogleLogging(argv[0]);
   InitGoogleTest(&argc, argv);
-#if defined(HAVE_SYMBOLIZE)
+#if defined(HAVE_SYMBOLIZE) && defined(HAVE_STACKTRACE)
 # if defined(__ELF__)
   // We don't want to get affected by the callback interface, that may be
   // used to install some callback function at InitGoogle() time.


### PR DESCRIPTION
When glog 0.4.0 is built using musl instead of glibc, the compilation
for this test fails because musl doesn't provide execinfo.h, which sets
HAVE_STACKTRACE to false.

Tested by building glog with musl and verifying that the build succeeds
with this patch. [See https://github.com/openwrt/packages/pull/8583]

Signed-off-by: Amol Bhave <ambhave@fb.com>