### PR TITLE
fix modifying variables by vulnerability 

### DIFF
--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -1340,7 +1340,7 @@ bool Demangle(const char *mangled, char *out, int out_size) {
     // Extract the string `(?...)`
     const char *rparen = strchr(lparen, ')');
     size_t length = rparen - lparen - 1;
-    strncpy(buffer, lparen + 1, length);
+    strlcpy(buffer, lparen + 1, length);
     buffer[length] = '\0';
     mangled = buffer;
   } // Else the symbol wasn't inside a set of parentheses

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -450,8 +450,8 @@ static inline string Munge(const string& filename) {
     string line = MungeLine(buf);
     char null_str[256];
     char ptr_str[256];
-    sprintf(null_str, "%p", static_cast<void*>(NULL));
-    sprintf(ptr_str, "%p", reinterpret_cast<void*>(PTR_TEST_VALUE));
+    snprintf(null_str, "%p", static_cast<void*>(NULL));
+    snprintf(ptr_str, "%p", reinterpret_cast<void*>(PTR_TEST_VALUE));
 
     StringReplace(&line, "__NULLP__", null_str);
     StringReplace(&line, "__PTRTEST__", ptr_str);

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -2086,7 +2086,7 @@ int posix_strerror_r(int err, char *buf, size_t len) {
         return -1;
       }
 #endif
-      strncat(buf, rc, len-1);
+      strlcat(buf, rc, len-1);
       return 0;
     }
   }

--- a/src/stl_logging_unittest.cc
+++ b/src/stl_logging_unittest.cc
@@ -136,7 +136,7 @@ static void TestSTLLogging() {
       v.push_back(i);
       if (i > 0) expected += ' ';
       char buf[256];
-      sprintf(buf, "%d", i);
+      snprintf(buf, "%d", i);
       expected += buf;
     }
     v.push_back(100);

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -844,7 +844,7 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
   Dl_info info;
   if (dladdr(pc, &info)) {
     if ((int)strlen(info.dli_sname) < out_size) {
-      strcpy(out, info.dli_sname);
+      strlcpy(out, info.dli_sname);
       // Symbolization succeeded.  Now we try to demangle the symbol.
       DemangleInplace(out, out_size);
       return true;

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -651,7 +651,7 @@ OpenObjectFileContainingPcAndGetStartAddress(uint64_t pc,
     if (object_fd < 0) {
       // Failed to open object file.  Copy the object file name to
       // |out_file_name|.
-      strncpy(out_file_name, cursor, out_file_name_size);
+      strlcpy(out_file_name, cursor, out_file_name_size);
       // Making sure |out_file_name| is always null-terminated.
       out_file_name[out_file_name_size - 1] = '\0';
       return -1;
@@ -735,7 +735,7 @@ static void SafeAppendString(const char* source, char* dest, int dest_size) {
   SAFE_ASSERT(dest_string_length < dest_size);
   dest += dest_string_length;
   dest_size -= dest_string_length;
-  strncpy(dest, source, dest_size);
+  strlcpy(dest, source, dest_size);
   // Making sure |dest| is always null-terminated.
   dest[dest_size - 1] = '\0';
 }
@@ -909,7 +909,7 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
                          reinterpret_cast<DWORD64>(pc), 0, symbol);
   if (ret == 1 && static_cast<int>(symbol->NameLen) < out_size) {
     // `NameLen` does not include the null terminating character.
-    strncpy(out, symbol->Name, static_cast<size_t>(symbol->NameLen) + 1);
+    strlcpy(out, symbol->Name, static_cast<size_t>(symbol->NameLen) + 1);
     out[static_cast<size_t>(symbol->NameLen)] = '\0';
     // Symbolization succeeded.  Now we try to demangle the symbol.
     DemangleInplace(out, out_size);


### PR DESCRIPTION
It updates some variables recommended and suggested by apple that currently affect native react for development in ios using pod

https://developer.apple.com/library/archive/documentation/Security/Conceptual/SecureCodingGuide/Articles/BufferOverflows.html#//apple_ref/doc/uid/TP40002577-SW1

issue (App security test reports Insecure API for React Native iOS App - Binary Analysis (IPA) #453)