### PR TITLE
I supported clang-cl with BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,13 +531,13 @@ if (NOT BUILD_SHARED_LIBS)
 else (NOT BUILD_SHARED_LIBS)
   target_compile_definitions (glog PRIVATE GOOGLE_GLOG_IS_A_DLL=1)
 
-  if (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT)
+  if (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT AND NOT MSVC)
     set (_EXPORT "__attribute__((visibility(\"default\")))")
     set (_IMPORT "")
   elseif (HAVE___DECLSPEC)
     set (_EXPORT "__declspec(dllexport)")
     set (_IMPORT "__declspec(dllimport)")
-  endif (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT)
+  endif (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT AND NOT MSVC)
 
   target_compile_definitions (glog PRIVATE
     "GOOGLE_GLOG_DLL_DECL=${_EXPORT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,13 +531,13 @@ if (NOT BUILD_SHARED_LIBS)
 else (NOT BUILD_SHARED_LIBS)
   target_compile_definitions (glog PRIVATE GOOGLE_GLOG_IS_A_DLL=1)
 
-  if (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT AND NOT MSVC)
-    set (_EXPORT "__attribute__((visibility(\"default\")))")
-    set (_IMPORT "")
-  elseif (HAVE___DECLSPEC)
+  if (HAVE___DECLSPEC)
     set (_EXPORT "__declspec(dllexport)")
     set (_IMPORT "__declspec(dllimport)")
-  endif (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT AND NOT MSVC)
+  elseif (HAVE___ATTRIBUTE__VISIBILITY_DEFAULT)
+    set (_EXPORT "__attribute__((visibility(\"default\")))")
+    set (_IMPORT "")
+  endif (HAVE___DECLSPEC)
 
   target_compile_definitions (glog PRIVATE
     "GOOGLE_GLOG_DLL_DECL=${_EXPORT}")


### PR DESCRIPTION
clang-cl (clang for msvc) can compiles ``` static void foo(void) __attribute__ ((visibility(\"default\"))); ```
But functions are not exported as DLL functions.
So these errors are caused.

```
undefined symbol: "void __cdecl google::ShutdownGoogleLogging(void)" (?ShutdownGoogleLogging@google@@YAXXZ)	logging_unittest	D:\Dev\glog\build_\lld-link	1	
undefined symbol: "void __cdecl google::RawLog__(int, char const *, int, char const *)" (?RawLog__@google@@YAXHPBDH0ZZ)	logging_unittest	D:\Dev\glog\build_\lld-link	1	
undefined symbol: "void __cdecl google::InstallFailureWriter(void (__cdecl *)(char const *, int))" (?InstallFailureWriter@google@@YAXP6AXPBDH@Z@Z)	signalhandler_unittest	D:\Dev\glog\build_\lld-link	1	
```

I made HAVE___ATTRIBUTE__VISIBILITY_DEFAULT disabled on MSVC.
