### PR TITLE
Fix const_basename on windows host and linux target

### DIFF
--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -284,10 +284,8 @@ pid_t GetTID() {
 
 const char* const_basename(const char* filepath) {
   const char* base = strrchr(filepath, '/');
-#ifdef OS_WINDOWS  // Look for either path separator in Windows
   if (!base)
     base = strrchr(filepath, '\\');
-#endif
   return base ? (base+1) : filepath;
 }
 


### PR DESCRIPTION
I use GCC for arm linux target compiled for windows host(Linaro arm-linux-gnueabihf for mingw). And const_basename doesn't work. On my linux taget I see full path instead of basename. e.g.

I0905 19:46:34.622531  1536 Z:\dev\visa_server\src\main.cpp:115] Hello World
I0905 19:46:34.628554  1536 Z:\dev\visa_server\src\main.cpp:123] Yo
