### PR TITLE
src/utilities: fix build without pthread

### DIFF
--- a/src/utilities.h
+++ b/src/utilities.h
@@ -163,8 +163,6 @@ const char* ProgramInvocationShortName();
 
 bool IsGoogleLoggingInitialized();
 
-bool is_default_thread();
-
 int64 CycleClock_Now();
 
 int64 UsecToCycles(int64 usec);


### PR DESCRIPTION
- Remove is_default_thread function which is an internal and not used
  function
- Remove g_main_thread_id as it was used only by is_default_thread

Fixes:
 - http://autobuild.buildroot.net/results/5320bbe1205e782e3516d9bead8d1ed825bcbaad

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>