### PR TITLE
logging: Fix compilation with uClibc++

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1320,7 +1320,7 @@ inline void LogAtLevel(int const severity, std::string const &msg) {
 // reasonably good C++11 support, so we set LANG_CXX for it and
 // newer versions (_MSC_VER >= 1900).
 #if (defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L || \
-     (defined(_MSC_VER) && _MSC_VER >= 1900))
+     (defined(_MSC_VER) && _MSC_VER >= 1900)) && !defined(__UCLIBCXX_MAJOR__)
 // Helper for CHECK_NOTNULL().
 //
 // In C++11, all cases can be handled by a single function. Since the value


### PR DESCRIPTION
uClibc++ has compiler support for C++11, but not the functions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

eg: It can support auto, range based for loops, noexcept, but not std::forward or what have you.