### PR TITLE
src/symbolize.cc: do not check for HAVE_DLFCN_H for macOS

### DIFF
--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -834,7 +834,7 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
 
 _END_GOOGLE_NAMESPACE_
 
-#elif defined(OS_MACOSX) && defined(HAVE_DLADDR) && defined(HAVE_DLFCN_H)
+#elif defined(OS_MACOSX) && defined(HAVE_DLADDR)
 
 #include <dlfcn.h>
 #include <string.h>


### PR DESCRIPTION
This seems to raise a build failure, see
https://github.com/google/glog/commit/10498b485fe1007f8e913bf2c39ff39fe01c8dc8#commitcomment-35770392

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>