### PR TITLE
Add windows support for bazel build

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -15,3 +15,11 @@ platforms:
     - "..."
     test_targets:
     - "..."
+  windows:
+    # Optional: use VS 2017 instead of 2015.
+    environment:
+      BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC"
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -7,95 +7,95 @@
 #       https://github.com/google/glog/issues/61
 #       https://github.com/google/glog/files/393474/BUILD.txt
 
-def glog_library(namespace='google', with_gflags=1, **kwargs):
-    if native.repository_name() != '@':
-        gendir = '$(GENDIR)/external/' + native.repository_name().lstrip('@')
+def glog_library(namespace = "google", with_gflags = 1, **kwargs):
+    if native.repository_name() != "@":
+        gendir = "$(GENDIR)/external/" + native.repository_name().lstrip("@")
     else:
-        gendir = '$(GENDIR)'
+        gendir = "$(GENDIR)"
 
     native.cc_library(
-        name = 'glog',
-        visibility = [ '//visibility:public' ],
+        name = "glog",
+        visibility = ["//visibility:public"],
         srcs = [
-            ':config_h',
-            'src/base/commandlineflags.h',
-            'src/base/googleinit.h',
-            'src/base/mutex.h',
-            'src/demangle.cc',
-            'src/demangle.h',
-            'src/logging.cc',
-            'src/raw_logging.cc',
-            'src/signalhandler.cc',
-            'src/stacktrace.h',
-            'src/stacktrace_generic-inl.h',
-            'src/stacktrace_libunwind-inl.h',
-            'src/stacktrace_powerpc-inl.h',
-            'src/stacktrace_windows-inl.h',
-            'src/stacktrace_x86-inl.h',
-            'src/stacktrace_x86_64-inl.h',
-            'src/symbolize.cc',
-            'src/symbolize.h',
-            'src/utilities.cc',
-            'src/utilities.h',
-            'src/vlog_is_on.cc',
+            ":config_h",
+            "src/base/commandlineflags.h",
+            "src/base/googleinit.h",
+            "src/base/mutex.h",
+            "src/demangle.cc",
+            "src/demangle.h",
+            "src/logging.cc",
+            "src/raw_logging.cc",
+            "src/signalhandler.cc",
+            "src/stacktrace.h",
+            "src/stacktrace_generic-inl.h",
+            "src/stacktrace_libunwind-inl.h",
+            "src/stacktrace_powerpc-inl.h",
+            "src/stacktrace_windows-inl.h",
+            "src/stacktrace_x86-inl.h",
+            "src/stacktrace_x86_64-inl.h",
+            "src/symbolize.cc",
+            "src/symbolize.h",
+            "src/utilities.cc",
+            "src/utilities.h",
+            "src/vlog_is_on.cc",
         ],
         hdrs = [
-            ':logging_h',
-            ':raw_logging_h',
-            ':stl_logging_h',
-            ':vlog_is_on_h',
-            'src/glog/log_severity.h',
+            ":logging_h",
+            ":raw_logging_h",
+            ":stl_logging_h",
+            ":vlog_is_on_h",
+            "src/glog/log_severity.h",
         ],
-        strip_include_prefix = 'src',
+        strip_include_prefix = "src",
         copts = [
             # Disable warnings that exists in glog.
-            '-Wno-sign-compare',
-            '-Wno-unused-function',
-            '-Wno-unused-local-typedefs',
-            '-Wno-unused-variable',
+            "-Wno-sign-compare",
+            "-Wno-unused-function",
+            "-Wno-unused-local-typedefs",
+            "-Wno-unused-variable",
             "-DGLOG_BAZEL_BUILD",
             # Inject a C++ namespace.
             "-DGOOGLE_NAMESPACE='%s'" % namespace,
             # Allows src/base/mutex.h to include pthread.h.
-            '-DHAVE_PTHREAD',
+            "-DHAVE_PTHREAD",
             # Allows src/logging.cc to determine the host name.
-            '-DHAVE_SYS_UTSNAME_H',
+            "-DHAVE_SYS_UTSNAME_H",
             # For src/utilities.cc.
-            '-DHAVE_SYS_SYSCALL_H',
-            '-DHAVE_SYS_TIME_H',
-            '-DHAVE_STDINT_H',
-            '-DHAVE_STRING_H',
+            "-DHAVE_SYS_SYSCALL_H",
+            "-DHAVE_SYS_TIME_H",
+            "-DHAVE_STDINT_H",
+            "-DHAVE_STRING_H",
             # Enable dumping stacktrace upon sigaction.
-            '-DHAVE_SIGACTION',
+            "-DHAVE_SIGACTION",
             # For logging.cc.
-            '-DHAVE_PREAD',
-            '-DHAVE___ATTRIBUTE__',
+            "-DHAVE_PREAD",
+            "-DHAVE___ATTRIBUTE__",
 
             # Include generated header files.
-            '-I%s/glog_internal' % gendir,
+            "-I%s/glog_internal" % gendir,
         ] + select({
             # For stacktrace.
-            '@bazel_tools//src/conditions:darwin': [
-                '-DHAVE_UNWIND_H',
-                '-DHAVE_DLADDR',
+            "@bazel_tools//src/conditions:darwin": [
+                "-DHAVE_UNWIND_H",
+                "-DHAVE_DLADDR",
             ],
-            '//conditions:default': [
-                '-DHAVE_UNWIND_H',
+            "//conditions:default": [
+                "-DHAVE_UNWIND_H",
             ],
         }) + ([
             # Use gflags to parse CLI arguments.
-            '-DHAVE_LIB_GFLAGS',
+            "-DHAVE_LIB_GFLAGS",
         ] if with_gflags else []),
         deps = [
-            '@com_github_gflags_gflags//:gflags',
+            "@com_github_gflags_gflags//:gflags",
         ] if with_gflags else [],
         **kwargs
     )
 
     native.genrule(
-        name = 'gen_sh',
+        name = "gen_sh",
         outs = [
-            'gen.sh',
+            "gen.sh",
         ],
         cmd = r'''\
 #!/bin/sh
@@ -119,30 +119,32 @@ EOF
     )
 
     native.genrule(
-        name = 'config_h',
+        name = "config_h",
         srcs = [
-            'src/config.h.cmake.in',
+            "src/config.h.cmake.in",
         ],
         outs = [
-            'glog_internal/config.h',
+            "glog_internal/config.h",
         ],
         cmd = "awk '{ gsub(/^#cmakedefine/, \"//cmakedefine\"); print; }' $< > $@",
     )
 
-    [native.genrule(
-        name = '%s_h' % f,
-        srcs = [
-            'src/glog/%s.h.in' % f,
-        ],
-        outs = [
-            'src/glog/%s.h' % f,
-        ],
-        cmd = '$(location :gen_sh) < $< > $@',
-        tools = [':gen_sh'],
-    ) for f in [
-            'vlog_is_on',
-            'stl_logging',
-            'raw_logging',
-            'logging',
+    [
+        native.genrule(
+            name = "%s_h" % f,
+            srcs = [
+                "src/glog/%s.h.in" % f,
+            ],
+            outs = [
+                "src/glog/%s.h" % f,
+            ],
+            cmd = "$(location :gen_sh) < $< > $@",
+            tools = [":gen_sh"],
+        )
+        for f in [
+            "vlog_is_on",
+            "stl_logging",
+            "raw_logging",
+            "logging",
         ]
     ]


### PR DESCRIPTION
Attempt to fix https://github.com/google/glog/issues/472

linux/darwnin builds are not strictly equivalent to windows build. But it seem to already be that case without bazel, as we use pre-generated glog headers, that have hardcoded namespace for example.

Also, it doesn't support static linkage, but again, that seemed to already be hardcoded that way for windows when using pre-generated headers.

Windows support is far from perfect but it is at a least a step forward.