### PR TITLE
Address review comments for Bazel/Win32 build

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -6,6 +6,8 @@
 # This file is inspired by the following sample BUILD files:
 #       https://github.com/google/glog/issues/61
 #       https://github.com/google/glog/files/393474/BUILD.txt
+#
+# Known issue: the namespace parameter is not supported on Win32.
 
 def glog_library(namespace = "google", with_gflags = 1, **kwargs):
     if native.repository_name() != "@":

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -118,15 +118,9 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         name = "windows_glog_headers",
         hdrs = native.glob(["src/windows/glog/*.h"]),
         strip_include_prefix = "src/windows",
-        # TODO(rodrigoq): are these necessary?
-        # config.h for windows seem hardcoded that way,
-        # and we need to propagate those defines to binaries/libraries linking
-        # against glog.
-        defines = [
-            "GOOGLE_GLOG_IS_A_DLL=1",
-            "GOOGLE_GLOG_DLL_DECL=__declspec(dllexport)",
-            "GOOGLE_GLOG_DLL_DECL_FOR_UNITTEST=__declspec(dllimport)",
-        ],
+        # We need to override the default GOOGLE_GLOG_DLL_DECL from
+        # src/windows/glog/*.h to match src/windows/config.h.
+        defines = ["GOOGLE_GLOG_DLL_DECL=__declspec(dllexport)"],
         deps = [":strip_include_prefix_hack"],
     )
 


### PR DESCRIPTION
This prevents leaking `config.h` and some unnecessary defines to rules that depend on glog. It also adds a caveat about not supporting the `namespace` parameter.

@skeptic-monkey, could you check that these changes work with your use case?