### PR TITLE
Fix missing deletion of custom Logger

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -495,7 +495,7 @@ class LogDestination {
 
  private:
   LogDestination(LogSeverity severity, const char* base_filename);
-  ~LogDestination() { }
+  ~LogDestination();
 
   // Take a log message of a particular severity and log it to stderr
   // iff it's of a high enough severity to deserve it.
@@ -580,6 +580,13 @@ LogDestination::LogDestination(LogSeverity severity,
                                const char* base_filename)
   : fileobject_(severity, base_filename),
     logger_(&fileobject_) {
+}
+
+LogDestination::~LogDestination() {
+  if (logger_ && logger_ != &fileobject_) {
+    // Delete user-specified logger set via SetLogger().
+    delete logger_;
+  }
 }
 
 inline void LogDestination::FlushLogFilesUnsafe(int min_severity) {


### PR DESCRIPTION
- If the user specifies a custom Logger via SetLogger(), the docs state
  that the logging module takes ownership of it.  Prior to this change,
  the logging library was not deleting a custom logger when the
  LogDestination which owns it was destroyed.