### PR TITLE
Don't call close(2) more than once

### DIFF
--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -374,7 +374,7 @@ struct FileDescriptor {
   explicit FileDescriptor(int fd) : fd_(fd) {}
   ~FileDescriptor() {
     if (fd_ >= 0) {
-      NO_INTR(close(fd_));
+      close(fd_);
     }
   }
   int get() { return fd_; }


### PR DESCRIPTION
Don't call close(2) more then once, even though close(2) returns -1.

See the manual page for details.