### PR TITLE
Use file offsets in traces if object has no symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option (WITH_THREADS "Enable multithreading support" ON)
 option (WITH_TLS "Enable Thread Local Storage (TLS) support" ON)
 option (BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option (PRINT_UNSYMBOLIZED_STACK_TRACES
-  "Print raw pc values on symbolization failure" OFF)
+  "Print file offsets in traces instead of symbolizing" OFF)
 option (WITH_PKGCONFIG "Enable pkg-config support" ON)
 option (WITH_UNWIND "Enable libunwind support" ON)
 

--- a/configure.ac
+++ b/configure.ac
@@ -209,11 +209,11 @@ AC_DEFINE_UNQUOTED(TEST_SRC_DIR, "$srcdir", [location of source code])
 
 AC_ARG_ENABLE(unsymbolized-traces,
               AS_HELP_STRING([--enable-unsymbolized-traces],
-                             [Print raw pc values when symbolization is failed.]),
+                             [Print file offsets in traces instead of symbolizing.]),
               enable_unsymbolized_traces=yes)
 if test x"$enable_unsymbolized_traces" = x"yes"; then
   AC_DEFINE(PRINT_UNSYMBOLIZED_STACK_TRACES, 1,
-            [define if we should print raw pc values on symbolization failure.])
+            [define if we should print file offsets in traces instead of symbolizing.])
 fi
 
 # These are what's needed by logging.h.in and raw_logging.h.in

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -170,7 +170,7 @@
 /* How to access the PC from a struct ucontext */
 #cmakedefine PC_FROM_UCONTEXT
 
-/* define if we should print raw pc values on symbolization failure. */
+/* define if we should print file offsets in traces instead of symbolizing. */
 #cmakedefine PRINT_UNSYMBOLIZED_STACK_TRACES
 
 /* Define to necessary symbol if this constant uses a non-standard name on

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -312,6 +312,7 @@ FindSymbol(uint64_t pc, const int fd, char *out, int out_size,
         ssize_t len1 = ReadFromOffset(fd, out, out_size,
                                       strtab->sh_offset + symbol.st_name);
         if (len1 <= 0 || memchr(out, '\0', out_size) == NULL) {
+          memset(out, 0, out_size);
           return false;
         }
         return true;  // Obtained the symbol name.
@@ -783,9 +784,10 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
                                                              out_size - 1);
   }
 
+  FileDescriptor wrapped_object_fd(object_fd);
+
 #if defined(PRINT_UNSYMBOLIZED_STACK_TRACES)
   {
-    FileDescriptor wrapped_object_fd(object_fd);
 #else
   // Check whether a file name was returned.
   if (object_fd < 0) {
@@ -804,7 +806,6 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
     // Failed to determine the object file containing PC.  Bail out.
     return false;
   }
-  FileDescriptor wrapped_object_fd(object_fd);
   int elf_type = FileGetElfType(wrapped_object_fd.get());
   if (elf_type == -1) {
     return false;
@@ -824,6 +825,17 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
   }
   if (!GetSymbolFromObjectFile(wrapped_object_fd.get(), pc0,
                                out, out_size, base_address)) {
+    if (out[1] && !g_symbolize_callback) {
+      // The object file containing PC was opened successfully however the
+      // symbol was not found. The object may have been stripped. This is still
+      // considered success because the object file name and offset are known
+      // and tools like asan_symbolize.py can be used for the symbolization.
+      out[out_size - 1] = '\0';  // Making sure |out| is always null-terminated.
+      SafeAppendString("+0x", out, out_size);
+      SafeAppendHexNumber(pc0 - base_address, out, out_size);
+      SafeAppendString(")", out, out_size);
+      return true;
+    }
     return false;
   }
 


### PR DESCRIPTION
Use file offsets in traces if object has no symbols

Fallback to using file offsets if no symbol is found, like we do if the
object could not be opened.

This makes backtraces usable even if objects in the trace are stripped,
since the trace can be symbolized by post-processing it with a tool like
asan_symbolize.py.

Note that this is not currently compatible with SymbolizeCallback as
this overwrites the filename in the buffer. The behavior is unchanged
in that case.

Closes: #514