### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -76,7 +76,7 @@ You can download and install glog using the [vcpkg](https://github.com/Microsoft
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
-    vcpkg install glog
+    ./vcpkg install glog
 
 The glog port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 

--- a/INSTALL
+++ b/INSTALL
@@ -67,20 +67,6 @@ frame pointer based stack unwinder by passing the
 --enable-frame-pointers flag to configure.
 
 
-Building glog - Using vcpkg
-===========================
-
-You can download and install glog using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    ./vcpkg install glog
-
-The glog port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
-
-
 Basic Installation
 ==================
 
@@ -143,6 +129,22 @@ The simplest way to compile this package is:
 
   6. Often, you can also type `make uninstall' to remove the installed
      files again.
+
+
+Building glog - Using vcpkg
+===========================
+
+The url of vcpkg is: https://github.com/Microsoft/vcpkg
+You can download and install glog using the vcpkg dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install glog
+
+The glog port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request on the vcpkg repository.
+
 
 Compilers and Options
 =====================

--- a/INSTALL
+++ b/INSTALL
@@ -67,6 +67,20 @@ frame pointer based stack unwinder by passing the
 --enable-frame-pointers flag to configure.
 
 
+Building glog - Using vcpkg
+===========================
+
+You can download and install glog using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install glog
+
+The glog port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 Basic Installation
 ==================
 


### PR DESCRIPTION
Glog is available as a port in vcpkg, a C++ library manager that simplifies installation for glog and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build glog, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.