### PR TITLE
Add target existence checks to Unwind find module

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,8 +34,8 @@ Ivan Penkov <ivanpe@google.com>
 Jacob Trimble <modmaker@google.com>
 Jim Ray <jimray@google.com>
 Marco Wang <m.aesophor@gmail.com>
-Michael Tanner <michael@tannertaxpro.com>
 Michael Darr <mdarr@matician.com>
+Michael Tanner <michael@tannertaxpro.com>
 MiniLight <MiniLightAR@Gmail.com>
 Peter Collingbourne <pcc@google.com>
 Rodrigo Queiro <rodrigoq@google.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,6 +35,7 @@ Jacob Trimble <modmaker@google.com>
 Jim Ray <jimray@google.com>
 Marco Wang <m.aesophor@gmail.com>
 Michael Tanner <michael@tannertaxpro.com>
+Michael Darr <mdarr@matician.com>
 MiniLight <MiniLightAR@Gmail.com>
 Peter Collingbourne <pcc@google.com>
 Rodrigo Queiro <rodrigoq@google.com>

--- a/cmake/FindUnwind.cmake
+++ b/cmake/FindUnwind.cmake
@@ -62,15 +62,17 @@ find_package_handle_standard_args (Unwind REQUIRED_VARS Unwind_INCLUDE_DIR
   Unwind_LIBRARY Unwind_PLATFORM_LIBRARY VERSION_VAR Unwind_VERSION)
 
 if (Unwind_FOUND)
-  add_library (unwind::unwind INTERFACE IMPORTED)
+  if (NOT TARGET unwind::unwind)
+    add_library (unwind::unwind INTERFACE IMPORTED)
 
-  set_property (TARGET unwind::unwind PROPERTY
-    INTERFACE_INCLUDE_DIRECTORIES ${Unwind_INCLUDE_DIR}
-  )
-  set_property (TARGET unwind::unwind PROPERTY
-    INTERFACE_LINK_LIBRARIES ${Unwind_LIBRARY} ${Unwind_PLATFORM_LIBRARY}
-  )
-  set_property (TARGET unwind::unwind PROPERTY
-    IMPORTED_CONFIGURATIONS RELEASE
-  )
+    set_property (TARGET unwind::unwind PROPERTY
+      INTERFACE_INCLUDE_DIRECTORIES ${Unwind_INCLUDE_DIR}
+    )
+    set_property (TARGET unwind::unwind PROPERTY
+      INTERFACE_LINK_LIBRARIES ${Unwind_LIBRARY} ${Unwind_PLATFORM_LIBRARY}
+    )
+    set_property (TARGET unwind::unwind PROPERTY
+      IMPORTED_CONFIGURATIONS RELEASE
+    )
+  endif(NOT TARGET unwind::unwind)
 endif (Unwind_FOUND)

--- a/cmake/FindUnwind.cmake
+++ b/cmake/FindUnwind.cmake
@@ -74,5 +74,5 @@ if (Unwind_FOUND)
     set_property (TARGET unwind::unwind PROPERTY
       IMPORTED_CONFIGURATIONS RELEASE
     )
-  endif(NOT TARGET unwind::unwind)
+  endif (NOT TARGET unwind::unwind)
 endif (Unwind_FOUND)


### PR DESCRIPTION
The build systems of projects depending on Glog may call the Unwind find
module multiple times. In these cases, the current unwind find module tries
to create a duplicate unwind::unwind target, crashing the build. This
patch adds an existence check before target creation to fix this issue.

Signed-off-by: Michael Darr <mdarr@matician.com>