### PR TITLE
Prepend the year to each glog line (#516)

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -280,12 +280,13 @@ typedef unsigned __int64 uint64;
 //
 // Log lines have this form:
 //
-//     Lmmdd hh:mm:ss.uuuuuu threadid file:line] msg...
+//     Lyyyymmdd hh:mm:ss.uuuuuu threadid file:line] msg...
 //
 // where the fields are defined as follows:
 //
 //   L                A single character, representing the log level
 //                    (eg 'I' for INFO)
+//   yyyy             The year
 //   mm               The month (zero padded; ie May is '05')
 //   dd               The day (zero padded)
 //   hh:mm:ss.uuuuuu  Time in hours, minutes and fractional seconds

--- a/src/glog/raw_logging.h.in
+++ b/src/glog/raw_logging.h.in
@@ -64,8 +64,8 @@
 //   RAW_LOG(ERROR, "Failed foo with %i: %s", status, error);
 //   RAW_VLOG(3, "status is %i", status);
 // These will print an almost standard log lines like this to stderr only:
-//   E0821 211317 file.cc:123] RAW: Failed foo with 22: bad_file
-//   I0821 211317 file.cc:142] RAW: status is 20
+//   E20200821 211317 file.cc:123] RAW: Failed foo with 22: bad_file
+//   I20200821 211317 file.cc:142] RAW: status is 20
 #define RAW_LOG(severity, ...) \
   do { \
     switch (@ac_google_namespace@::GLOG_ ## severity) {  \

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -385,12 +385,12 @@ static inline string GetCapturedTestStderr() {
   return GetCapturedTestOutput(STDERR_FILENO);
 }
 
-// Check if the string is [IWEF](\d{4}|DATE)
+// Check if the string is [IWEF](\d{8}|YEARDATE)
 static inline bool IsLoggingPrefix(const string& s) {
-  if (s.size() != 5) return false;
+  if (s.size() != 9) return false;
   if (!strchr("IWEF", s[0])) return false;
-  for (int i = 1; i <= 4; ++i) {
-    if (!isdigit(s[i]) && s[i] != "DATE"[i-1]) return false;
+  for (int i = 1; i <= 8; ++i) {
+    if (!isdigit(s[i]) && s[i] != "YEARDATE"[i-1]) return false;
   }
   return true;
 }
@@ -398,8 +398,8 @@ static inline bool IsLoggingPrefix(const string& s) {
 // Convert log output into normalized form.
 //
 // Example:
-//     I0102 030405 logging_unittest.cc:345] RAW: vlog -1
-//  => IDATE TIME__ logging_unittest.cc:LINE] RAW: vlog -1
+//     I20200102 030405 logging_unittest.cc:345] RAW: vlog -1
+//  => IYEARDATE TIME__ logging_unittest.cc:LINE] RAW: vlog -1
 static inline string MungeLine(const string& line) {
   std::istringstream iss(line);
   string before, logcode_date, time, thread_lineinfo;
@@ -428,7 +428,7 @@ static inline string MungeLine(const string& line) {
   thread_lineinfo = thread_lineinfo.substr(0, index+1) + "LINE]";
   string rest;
   std::getline(iss, rest);
-  return (before + logcode_date[0] + "DATE TIME__ " + thread_lineinfo +
+  return (before + logcode_date[0] + "YEARDATE TIME__ " + thread_lineinfo +
           MungeLine(rest));
 }
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1209,7 +1209,7 @@ void LogFileObject::Write(bool force_flush,
                        << setw(2) << tm_time.tm_sec << '\n'
                        << "Running on machine: "
                        << LogDestination::hostname() << '\n'
-                       << "Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu "
+                       << "Log line format: [IWEF]yyyymmdd hh:mm:ss.uuuuuu "
                        << "threadid file:line] msg" << '\n';
     const string& file_header_string = file_header_stream.str();
 
@@ -1421,11 +1421,12 @@ void LogMessage::Init(const char* file,
   data_->has_been_flushed_ = false;
 
   // If specified, prepend a prefix to each line.  For example:
-  //    I1018 160715 f5d4fbb0 logging.cc:1153]
-  //    (log level, GMT month, date, time, thread_id, file basename, line)
+  //    I20201018 160715 f5d4fbb0 logging.cc:1153]
+  //    (log level, GMT year, month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
     stream() << LogSeverityNames[severity][0]
+             << setw(4) << 1900+data_->tm_time_.tm_year
              << setw(2) << 1+data_->tm_time_.tm_mon
              << setw(2) << data_->tm_time_.tm_mday
              << ' '
@@ -1827,6 +1828,7 @@ string LogSink::ToString(LogSeverity severity, const char* file, int line,
   stream.fill('0');
 
   stream << LogSeverityNames[severity][0]
+         << setw(4) << 1900+tm_time->tm_year
          << setw(2) << 1+tm_time->tm_mon
          << setw(2) << tm_time->tm_mday
          << ' '

--- a/src/logging_unittest.err
+++ b/src/logging_unittest.err
@@ -1,307 +1,307 @@
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=2 logtostderr=0 alsologtostderr=0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=2 logtostderr=0 alsologtostderr=0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
 WARNING: Logging before InitGoogleLogging() is written to STDERR
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=0 logtostderr=0 alsologtostderr=0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] foo bar 10 3.4
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 1: __SUCCESS__ [0]
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 3, iteration 1
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 4, iteration 1
-WDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 5, iteration 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 1
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log if less than 3 every 2, iteration 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 2
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 3: __ENOENT__ [2]
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 3
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log if less than 3 every 2, iteration 3
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 3, iteration 4
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 4
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 5: __EINTR__ [4]
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 4, iteration 5
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 5
-WDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 5, iteration 6
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 6
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 7: __ENXIO__ [6]
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 3, iteration 7
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 7
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 8
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 9: __ENOEXEC__ [8]
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 4, iteration 9
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 9
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 3, iteration 10
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 10
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if this
-IDATE TIME__ THREADID logging_unittest.cc:LINE] array
-IDATE TIME__ THREADID logging_unittest.cc:LINE] const array
-EDATE TIME__ THREADID logging_unittest.cc:LINE] foo 1000 0000001000 3e8
-EDATE TIME__ THREADID logging_unittest.cc:LINE] inner
-EDATE TIME__ THREADID logging_unittest.cc:LINE] outer
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=0 logtostderr=0 alsologtostderr=0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] foo bar 10 3.4
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 1: __SUCCESS__ [0]
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 3, iteration 1
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 4, iteration 1
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 5, iteration 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 1
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if less than 3 every 2, iteration 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 2
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 3: __ENOENT__ [2]
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 3
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if less than 3 every 2, iteration 3
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 3, iteration 4
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 4
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 5: __EINTR__ [4]
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 4, iteration 5
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 5
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 5, iteration 6
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 6
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 7: __ENXIO__ [6]
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 3, iteration 7
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 7
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 8
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Plog every 2, iteration 9: __ENOEXEC__ [8]
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 4, iteration 9
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 9
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log every 3, iteration 10
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 10
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if this
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] array
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] const array
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] foo 1000 0000001000 3e8
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] inner
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] outer
 no prefix
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo bar 10 3.400000
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: array
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: const array
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: ptr __PTRTEST__
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: ptr __NULLP__
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo 1000 0000001000 3e8
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo 1000
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo 1000
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: RAW_LOG ERROR: The Message was too long!
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: RAW_LOG ERROR: The Message was too long!
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0 on
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 1 on
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 2 on
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=0 logtostderr=0 alsologtostderr=0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=1 stderrthreshold=0 logtostderr=0 alsologtostderr=0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=-1 stderrthreshold=0 logtostderr=0 alsologtostderr=0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=1 logtostderr=0 alsologtostderr=0
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=2 logtostderr=0 alsologtostderr=0
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=3 logtostderr=0 alsologtostderr=0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=3 logtostderr=1 alsologtostderr=0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=3 logtostderr=0 alsologtostderr=1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=1 stderrthreshold=1 logtostderr=0 alsologtostderr=0
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=1 stderrthreshold=3 logtostderr=0 alsologtostderr=1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
-EDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
-IDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected info
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected warning
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_SINK:
-IDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected info
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected warning
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported info
-WDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported warning
-EDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported error
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffering
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffered
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waiting
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Sink got a messages
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waited
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: IDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
-EDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffering
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffered
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waiting
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Sink got a messages
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waited
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: EDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
-WDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffering
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffered
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waiting
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Sink got a messages
-IDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waited
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: WDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: IDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: EDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
-IDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: WDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo bar 10 3.400000
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: array
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: const array
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: ptr __PTRTEST__
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: ptr __NULLP__
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo 1000 0000001000 3e8
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo 1000
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: foo 1000
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: RAW_LOG ERROR: The Message was too long!
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: RAW_LOG ERROR: The Message was too long!
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0 on
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 1 on
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 2 on
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=0 logtostderr=0 alsologtostderr=0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=1 stderrthreshold=0 logtostderr=0 alsologtostderr=0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=-1 stderrthreshold=0 logtostderr=0 alsologtostderr=0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=1 logtostderr=0 alsologtostderr=0
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=2 logtostderr=0 alsologtostderr=0
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=3 logtostderr=0 alsologtostderr=0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=3 logtostderr=1 alsologtostderr=0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=0 stderrthreshold=3 logtostderr=0 alsologtostderr=1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=1 stderrthreshold=1 logtostderr=0 alsologtostderr=0
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Test: v=1 stderrthreshold=3 logtostderr=0 alsologtostderr=1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected info
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected warning
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_SINK:
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected info
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected warning
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffering
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffered
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waiting
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Sink got a messages
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waited
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffering
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffered
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waiting
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Sink got a messages
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waited
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffering
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Buffered
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waiting
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Sink got a messages
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] RAW: Waited
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3

--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -114,7 +114,7 @@ void RawLog__(LogSeverity severity, const char* file, int line,
   int size = sizeof(buffer);
 
   // NOTE: this format should match the specification in base/logging.h
-  DoRawLog(&buf, &size, "%c0000 00:00:00.000000 %5u %s:%d] RAW: ",
+  DoRawLog(&buf, &size, "%c00000000 00:00:00.000000 %5u %s:%d] RAW: ",
            LogSeverityNames[severity][0],
            static_cast<unsigned int>(GetTID()),
            const_basename(const_cast<char *>(file)), line);

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -284,12 +284,13 @@ typedef unsigned __int64 uint64;
 //
 // Log lines have this form:
 //
-//     Lmmdd hh:mm:ss.uuuuuu threadid file:line] msg...
+//     Lyyyymmdd hh:mm:ss.uuuuuu threadid file:line] msg...
 //
 // where the fields are defined as follows:
 //
 //   L                A single character, representing the log level
 //                    (eg 'I' for INFO)
+//   yyyy             The year
 //   mm               The month (zero padded; ie May is '05')
 //   dd               The day (zero padded)
 //   hh:mm:ss.uuuuuu  Time in hours, minutes and fractional seconds


### PR DESCRIPTION
This PR fixes issue #516 by prepending the year to each glog line.

Previous format of each line in a log file:
[IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg

New format:
[IWEF]yyyymmdd hh:mm:ss.uuuuuu threadid file:line] msg

<br>

This is what a log file will actually look like:
```
Log file created at: 2020/03/08 23:47:32
Running on machine: adagio
Log line format: [IWEF]yyyymmdd hh:mm:ss.uuuuuu threadid file:line] msg
I20200308 23:47:32.089828 400441 config.cc:27] Loading user configuration: /home/aesophor/.config/wmderland/config
I20200309 07:41:46.769781 400441 config.cc:27] Loading user configuration: /home/aesophor/.config/wmderland/config
```