### PR TITLE
Fix build for Emscripten

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -48,6 +48,28 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         "-I%s/glog_internal" % gendir,
     ]
 
+    native.config_setting(
+        name = "wasm",
+        values = {"cpu": "wasm"},
+    )
+
+    wasm_copts = [
+        # Inject a C++ namespace.
+        "-DGOOGLE_NAMESPACE='%s'" % namespace,
+        # Allows src/base/mutex.h to include pthread.h.
+        "-DHAVE_PTHREAD",
+        # Allows src/logging.cc to determine the host name.
+        "-DHAVE_SYS_UTSNAME_H",
+        # For src/utilities.cc. We have time.h, but not syscall.h.
+        "-DHAVE_SYS_TIME_H",
+        # Enable dumping stacktrace upon sigaction.
+        "-DHAVE_SIGACTION",
+        # For logging.cc.
+        "-DHAVE_PREAD",
+        "-DHAVE___ATTRIBUTE__",
+        "-I%s/glog_internal" % gendir,
+    ]
+
     freebsd_only_copts = [
         # Enable declaration of _Unwind_Backtrace
         "-D_GNU_SOURCE",
@@ -105,6 +127,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
                 "@bazel_tools//src/conditions:windows": common_copts + windows_only_copts,
                 "@bazel_tools//src/conditions:darwin": common_copts + linux_or_darwin_copts + darwin_only_copts,
                 "@bazel_tools//src/conditions:freebsd": common_copts + linux_or_darwin_copts + freebsd_only_copts,
+                ":wasm": common_copts + wasm_copts,
                 "//conditions:default": common_copts + linux_or_darwin_copts,
             }),
         deps = [

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -18,6 +18,12 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         gendir = "$(GENDIR)"
         src_windows = "src/windows"
 
+    # Config setting for WebAssembly target.
+    native.config_setting(
+        name = "wasm",
+        values = {"cpu": "wasm"},
+    )
+
     common_copts = [
         "-DGLOG_BAZEL_BUILD",
         "-DHAVE_STDINT_H",
@@ -25,7 +31,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         "-DHAVE_UNWIND_H",
     ] + (["-DHAVE_LIB_GFLAGS"] if with_gflags else [])
 
-    default_copts = [
+    wasm_copts = [
         # Disable warnings that exists in glog.
         "-Wno-sign-compare",
         "-Wno-unused-function",
@@ -47,7 +53,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         "-I%s/glog_internal" % gendir,
     ]
 
-    linux_or_darwin_copts = default_copts + [
+    linux_or_darwin_copts = wasm_copts + [
         # For src/utilities.cc.
         "-DHAVE_SYS_SYSCALL_H",
     ]
@@ -109,7 +115,8 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
                 "@bazel_tools//src/conditions:windows": common_copts + windows_only_copts,
                 "@bazel_tools//src/conditions:darwin": common_copts + linux_or_darwin_copts + darwin_only_copts,
                 "@bazel_tools//src/conditions:freebsd": common_copts + linux_or_darwin_copts + freebsd_only_copts,
-                "//conditions:default": common_copts + default_copts,
+                ":wasm": common_copts + wasm_copts,
+                "//conditions:default": common_copts + linux_or_darwin_copts,
             }),
         deps = [
             ":glog_headers",


### PR DESCRIPTION
The current Bazel build configuration assumes that <sys/syscall.h> is present on non-windows targets, which is not the case when building with [emscripten](https://github.com/emscripten-core/emscripten). This PR fixes the issue.