### PR TITLE
Remove dead references to bluelist/blacklist classes

### DIFF
--- a/doc/glog.html
+++ b/doc/glog.html
@@ -8,22 +8,6 @@
 <link href="http://www.google.com/favicon.ico" type="image/x-icon"
       rel="shortcut icon">
 <link href="designstyle.css" type="text/css" rel="stylesheet">
-<style type="text/css">
-<!--
-  ol.bluelist li {
-    color: #3366ff;
-    font-family: sans-serif;
-  }
-  ol.bluelist li p {
-    color: #000;
-    font-family: "Times Roman", times, serif;
-  }
-  ul.blacklist li {
-    color: #000;
-    font-family: "Times Roman", times, serif;
-  }
-//-->
-</style>
 </head>
 
 <body>


### PR DESCRIPTION
This propagates the term blacklist which holds negative racial connotations across a large set of projects. I initially came to replace this term, but I've now noticed it seems to be unused.