### PR TITLE
Add `override` to `LogStreamBuf::overflow()`

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1128,7 +1128,7 @@ class GOOGLE_GLOG_DLL_DECL LogStreamBuf : public std::streambuf {
   }
 
   // This effectively ignores overflow.
-  virtual int_type overflow(int_type ch) {
+  int_type overflow(int_type ch) {
     return ch;
   }
 

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -1129,7 +1129,7 @@ class GOOGLE_GLOG_DLL_DECL LogStreamBuf : public std::streambuf {
   }
 
   // This effectively ignores overflow.
-  virtual int_type overflow(int_type ch) {
+  int_type overflow(int_type ch) {
     return ch;
   }
 


### PR DESCRIPTION
This quiets warnings such as:
```c++
glog/logging.h:1122:20: 
error: ‘virtual std::basic_streambuf<char>::int_type google::base_logging::LogStreamBuf::overflow(std::basic_streambuf<char>::int_type)’ 
can be marked override [-Werror=suggest-override]
   virtual int_type overflow(int_type ch) {
                    ^~~~~~~~

```