### PR TITLE
Added check for if info.dli_sname is NULL

### DIFF
--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -857,11 +857,13 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
                                                     int out_size) {
   Dl_info info;
   if (dladdr(pc, &info)) {
-    if ((int)strlen(info.dli_sname) < out_size) {
-      strcpy(out, info.dli_sname);
-      // Symbolization succeeded.  Now we try to demangle the symbol.
-      DemangleInplace(out, out_size);
-      return true;
+    if (info.dli_sname) {
+      if ((int)strlen(info.dli_sname) < out_size) {
+        strcpy(out, info.dli_sname);
+        // Symbolization succeeded.  Now we try to demangle the symbol.
+        DemangleInplace(out, out_size);
+        return true;
+      }
     }
   }
   return false;


### PR DESCRIPTION
Check if `info.dli_sname` is `NULL`,
If the image containing `addr` is found, but no nearest symbol was found, the `dli_sname` and `dli_saddr` fields are set to `NULL`.