### PR TITLE
cmake: allow to disable symbolize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,7 +416,7 @@ if (WITH_SYMBOLIZE)
     }
     ]=] HAVE_SYMBOLIZE)
 
-  cmake_pop_check_state ()
+    cmake_pop_check_state ()
 
     if (HAVE_SYMBOLIZE)
       set (HAVE_STACKTRACE 1)
@@ -425,6 +425,11 @@ if (WITH_SYMBOLIZE)
     set (HAVE_SYMBOLIZE 1)
   endif (WIN32 OR CYGWIN)
 endif (WITH_SYMBOLIZE)
+
+# CMake manages symbolize availability. The definition is necessary only when
+# building the library. Switch to add_compile_definitions once we drop support
+# for CMake below version 3.12.
+add_definitions (-DGLOG_NO_SYMBOLIZE_DETECTION)
 
 check_cxx_source_compiles ("
 #include <cstdlib>

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -127,6 +127,7 @@
 # define HAVE_STACKTRACE
 #endif
 
+#ifndef GLOG_NO_SYMBOLIZE_DETECTION
 #ifndef HAVE_SYMBOLIZE
 // defined by gcc
 #if defined(__ELF__) && defined(OS_LINUX)
@@ -139,6 +140,7 @@
 # define HAVE_SYMBOLIZE
 #endif
 #endif // !defined(HAVE_SYMBOLIZE)
+#endif // !defined(GLOG_NO_SYMBOLIZE_DETECTION)
 
 #ifndef ARRAYSIZE
 // There is a better way, but this is good enough for our purpose.


### PR DESCRIPTION
Closes #563

@drigz ~~This change might break Bazel builds. Maybe there is an alternative to removal?~~