### PR TITLE
Add Windows builds using GitHub Actions

### DIFF
--- a/.github/workflows/windows-builds.yml
+++ b/.github/workflows/windows-builds.yml
@@ -1,0 +1,79 @@
+name: Windows builds
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # available environments: https://github.com/actions/virtual-environments
+    name: ${{matrix.config.name}} ${{matrix.build_type}}
+    runs-on: ${{matrix.config.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+          name: "vs-15-2017-win64-cxx11",
+          os: windows-2016,
+          generator: "Visual Studio 15 2017",
+          std: 11,
+          test_target: RUN_TESTS,
+          }
+        - {
+          name: "vs-16-2019-win64-cxx11",
+          os: windows-2019,
+          generator: "Visual Studio 16 2019",
+          std: 11,
+          test_target: RUN_TESTS,
+          }
+        - {
+          name: "vs-16-2019-win64-cxx17",
+          os: windows-2019,
+          generator: "Visual Studio 16 2019",
+          std: 17,
+          test_target: RUN_TESTS,
+          }
+        - {
+          name: "mingw-cxx11",
+          os: windows-latest,
+          generator: "MinGW Makefiles",
+          std: 11,
+          test_target: test,
+          }
+        - {
+          name: "mingw-cxx17",
+          os: windows-latest,
+          generator: "MinGW Makefiles",
+          std: 17,
+          test_target: test,
+          }
+        build_type: [Debug] #, Release]
+        ARCH: ["x64"]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Visual Studio build steps
+    - name: Configure build MSVC
+      if: ${{ startswith(matrix.config.name, 'vs-') }}
+      shell: powershell
+      run: cmake -S . -B ${{runner.workspace}}/build_${{matrix.config.name}}_${{matrix.build_type}} -G "${{matrix.config.generator}}" -A "${{matrix.ARCH}}" -DCMAKE_CXX_STANDARD=${{matrix.config.std}} -DCMAKE_CXX_EXTENSIONS=OFF
+    - name: Build MSVC
+      if: ${{ startswith(matrix.config.name, 'vs-') }}
+      shell: powershell
+      run: cmake --build ${{runner.workspace}}/build_${{matrix.config.name}}_${{matrix.build_type}} --config ${{matrix.build_type}}
+
+    # mingw build steps
+    - name: Configure build MinGW
+      if: ${{ startswith(matrix.config.name, 'mingw-') }}
+      shell: powershell
+      run: cmake -S . -B ${{runner.workspace}}/build_${{matrix.config.name}}_${{matrix.build_type}} -G "${{matrix.config.generator}}" -DCMAKE_CXX_STANDARD=${{matrix.config.std}} -DCMAKE_CXX_EXTENSIONS=OFF -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+    - name: Build MinGW
+      if: ${{ startswith(matrix.config.name, 'mingw-') }}
+      shell: powershell
+      run: cmake --build ${{runner.workspace}}/build_${{matrix.config.name}}_${{matrix.build_type}}
+
+    - name: Run tests
+      shell: powershell
+      env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+      run: cmake --build ${{runner.workspace}}/build_${{matrix.config.name}}_${{matrix.build_type}} --target ${{matrix.config.test_target}}


### PR DESCRIPTION
Add VS 2017, VS 2019 and MinGW-w64 builds running the test cases. All
compiler have build jobs for C++11 and C++17.

Currently only the build-type 'Debug' is used, but can easily be
extended to build both 'Debug' and 'Release'.

- The Builds work fine based on `v0.4.0`
  - https://github.com/NeroBurner/glog/actions/runs/727394817
- All builds work on `v0.5.0-rc1`, but some tests fail
  - https://github.com/NeroBurner/glog/actions/runs/727397014
  - the VS 2019 builds and tests are green
  - VS 2017 test is failing
  - MinGW test is failing
- current master all jobs failing, some builds fail, some tests fail
  -  https://github.com/NeroBurner/glog/actions/runs/727392380
  - VS 2017 and VS 2019 have some linker error during build
  - MinGW is failing the tests

---

related PR: https://github.com/google/glog/pull/636

@sergiud please review