### PR TITLE
CHECK support for nullptr (fixes #341)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,12 @@ std::atomic<int> i;
 int main() { }
 " HAVE_CXX11_ATOMIC)
 
+check_cxx_source_compiles ("
+#include <cstddef>
+void foo(std::nullptr_t) {}
+int main(void) { foo(nullptr); }
+" HAVE_CXX11_NULLPTR_T)
+
 if (WITH_TLS)
   # Cygwin does not support the thread attribute. Don't bother.
   if (HAVE_GCC_TLS)
@@ -380,6 +386,12 @@ if (HAVE_USING_OPERATOR)
 else (HAVE_USING_OPERATOR)
   set (ac_cv_cxx_using_operator 0)
 endif (HAVE_USING_OPERATOR)
+
+if (HAVE_CXX11_NULLPTR_T)
+  set (ac_cv_cxx11_nullptr_t 1)
+else (HAVE_CXX11_NULLPTR_T)
+  set (ac_cv_cxx11_nullptr_t 0)
+endif (HAVE_CXX11_NULLPTR_T)
 
 if (HAVE_EXECINFO_H)
   set (HAVE_STACKTRACE 1)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,6 +26,7 @@ Abhishek Dasgupta <abhi2743@gmail.com>
 Abhishek Parmar <abhishek@orng.net>
 Andrew Schwartzmeyer <andrew@schwartzmeyer.com>
 Andy Ying <andy@trailofbits.com>
+Bret McKee <bretmckee@google.com>
 Brian Silverman <bsilver16384@gmail.com>
 Fumitoshi Ukai <ukai@google.com>
 Guillaume Dumont <dumont.guillaume@gmail.com>

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -50,6 +50,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         "-DGLOG_BAZEL_BUILD",
         # Inject a C++ namespace.
         "-DGOOGLE_NAMESPACE='%s'" % namespace,
+        "-DHAVE_CXX11_NULLPTR_T",
         "-DHAVE_STDINT_H",
         "-DHAVE_STRING_H",
         "-DHAVE_UNWIND_H",
@@ -186,6 +187,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
     )
 
     common_config = {
+        "@ac_cv_cxx11_nullptr_t@": "1",
         "@ac_cv_cxx_using_operator@": "1",
         "@ac_cv_have_inttypes_h@": "0",
         "@ac_cv_have_u_int16_t@": "0",

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -195,6 +195,9 @@
 /* Check whether C++11 atomic is available */
 #cmakedefine HAVE_CXX11_ATOMIC ${HAVE_CXX11_ATOMIC}
 
+/* Check whether C++11 nullptr_t is available */
+#cmakedefine HAVE_CXX11_NULLPTR_T ${HAVE_CXX11_NULLPTR_T}
+
 /* Version number of package */
 #cmakedefine VERSION
 

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -37,6 +37,7 @@
 #define _LOGGING_H_
 
 #include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <ctime>
 #include <iosfwd>
@@ -672,6 +673,13 @@ template <> GOOGLE_GLOG_DLL_DECL
 void MakeCheckOpValueString(std::ostream* os, const signed char& v);
 template <> GOOGLE_GLOG_DLL_DECL
 void MakeCheckOpValueString(std::ostream* os, const unsigned char& v);
+
+// This is required because nullptr is only present in c++ 11 and later.
+#if @ac_cv_cxx11_nullptr_t@
+// Provide printable value for nullptr_t
+template <> GOOGLE_GLOG_DLL_DECL
+void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& v);
+#endif
 
 // Build the error message string. Specify no inlining for code size.
 template <typename T1, typename T2>

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -2506,6 +2506,13 @@ void MakeCheckOpValueString(std::ostream* os, const unsigned char& v) {
   }
 }
 
+#ifdef HAVE_CXX11_NULLPTR_T
+template <>
+void MakeCheckOpValueString(std::ostream* os, const std::nullptr_t& v) {
+  (*os) << "nullptr";
+}
+#endif // defined(HAVE_CXX11_NULLPTR_T)
+
 void InitGoogleLogging(const char* argv0) {
   glog_internal_namespace_::InitGoogleLoggingUtilities(argv0);
 }


### PR DESCRIPTION
This allows `CHECK_NE(foo, nullptr)` to compile and produces "nullptr" for the string representation of `nullptr`.

Finalizes #342

Closes #562 #341 