### PR TITLE
readme: update CMake source directory option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ GNU Make as build tool, the typical workflow is:
 
   .. code:: bash
 
-     cmake -H . -B build -G "Unix Makefiles"
+     cmake -S . -B build -G "Unix Makefiles"
 
   CMake provides different generators, and by default will pick the most
   relevant one to your environment. If you need a specific version of Visual


### PR DESCRIPTION
-H flag has been replaced in 3.13 with the official source directory flag of -S.