### PR TITLE
Allow updating vmodule levels after vmodule level has been cached

### DIFF
--- a/src/glog/vlog_is_on.h.in
+++ b/src/glog/vlog_is_on.h.in
@@ -81,10 +81,10 @@
 // parsing of --vmodule flag and/or SetVLOGLevel calls.
 #define VLOG_IS_ON(verboselevel)                                \
   __extension__  \
-  ({ static @ac_google_namespace@::int32* vlocal__ = NULL;           \
+  ({ static @ac_google_namespace@::SiteFlag vlocal__{NULL, NULL, 0, NULL};       \
      @ac_google_namespace@::int32 verbose_level__ = (verboselevel);                    \
-     (vlocal__ == NULL ? @ac_google_namespace@::InitVLOG3__(&vlocal__, &FLAGS_v, \
-                        __FILE__, verbose_level__) : *vlocal__ >= verbose_level__); \
+     (vlocal__.level == NULL ? @ac_google_namespace@::InitVLOG3__(&vlocal__, &FLAGS_v, \
+                        __FILE__, verbose_level__) : *vlocal__.level >= verbose_level__); \
   })
 #else
 // GNU extensions not available, so we do not support --vmodule.
@@ -105,6 +105,13 @@ extern GOOGLE_GLOG_DLL_DECL int SetVLOGLevel(const char* module_pattern,
 
 // Various declarations needed for VLOG_IS_ON above: =========================
 
+struct SiteFlag {
+  @ac_google_namespace@::int32* level;
+  const char* base_name;
+  size_t base_len;
+  SiteFlag* next;
+};
+
 // Helper routine which determines the logging info for a particalur VLOG site.
 //   site_flag     is the address of the site-local pointer to the controlling
 //                 verbosity level
@@ -114,7 +121,7 @@ extern GOOGLE_GLOG_DLL_DECL int SetVLOGLevel(const char* module_pattern,
 // We will return the return value for VLOG_IS_ON
 // and if possible set *site_flag appropriately.
 extern GOOGLE_GLOG_DLL_DECL bool InitVLOG3__(
-    @ac_google_namespace@::int32** site_flag,
+    @ac_google_namespace@::SiteFlag* site_flag,
     @ac_google_namespace@::int32* site_default,
     const char* fname,
     @ac_google_namespace@::int32 verbose_level);

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -98,6 +98,7 @@ static void TestLogging(bool check_counts);
 static void TestRawLogging();
 static void LogWithLevels(int v, int severity, bool err, bool alsoerr);
 static void TestLoggingLevels();
+static void TestVLogModule();
 static void TestLogString();
 static void TestLogSink();
 static void TestLogToString();
@@ -223,6 +224,7 @@ int main(int argc, char **argv) {
   TestLogging(true);
   TestRawLogging();
   TestLoggingLevels();
+  TestVLogModule();
   TestLogString();
   TestLogSink();
   TestLogToString();
@@ -451,6 +453,24 @@ void TestLoggingLevels() {
   LogWithLevels(0, GLOG_FATAL, false, true);
   LogWithLevels(1, GLOG_WARNING, false, false);
   LogWithLevels(1, GLOG_FATAL, false, true);
+}
+
+int TestVlogHelper() {
+  if (VLOG_IS_ON(1)) {
+    return 1;
+  }
+  return 0;
+}
+
+void TestVLogModule() {
+  int c = TestVlogHelper();
+  EXPECT_EQ(0, c);
+
+#if defined(__GNUC__)
+  EXPECT_EQ(0, SetVLOGLevel("logging_unittest", 1));
+  c = TestVlogHelper();
+  EXPECT_EQ(1, c);
+#endif
 }
 
 TEST(DeathRawCHECK, logging) {


### PR DESCRIPTION
We maintain a linked list of all sites so we could invalidate those that should change upon SetVLOGLevel call.
Once site level starts pointing to module override it will be removed from the linked list to avoid unnecessary traversals.

Fixes #649 