### PR TITLE
Make LogCleaner support relative paths

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -478,7 +478,6 @@ class LogFileObject : public base::Logger {
 class LogCleaner {
  public:
   LogCleaner();
-  virtual ~LogCleaner() {}
 
   void Enable(int overdue_days);
   void Disable();
@@ -486,7 +485,7 @@ class LogCleaner {
            const string& base_filename,
            const string& filename_extension) const;
 
-  inline bool enabled() const { return enabled_; }
+  bool enabled() const { return enabled_; }
 
  private:
   vector<string> GetOverdueLogNames(string log_directory,
@@ -1296,9 +1295,6 @@ void LogFileObject::Write(bool force_flush,
 
     // Remove old logs
     if (log_cleaner.enabled()) {
-      if (base_filename_selected_ && base_filename_.empty()) {
-        return;
-      }
       log_cleaner.Run(base_filename_selected_,
                       base_filename_,
                       filename_extension_);
@@ -1324,6 +1320,7 @@ void LogCleaner::Run(bool base_filename_selected,
                      const string& base_filename,
                      const string& filename_extension) const {
   assert(enabled_ && overdue_days_ >= 0);
+  assert(!base_filename_selected || !base_filename.empty());
 
   vector<string> dirs;
 
@@ -1361,7 +1358,6 @@ vector<string> LogCleaner::GetOverdueLogNames(string log_directory,
   // Try to get all files within log_directory.
   DIR *dir;
   struct dirent *ent;
-
 
   if ((dir = opendir(log_directory.c_str()))) {
     while ((ent = readdir(dir))) {


### PR DESCRIPTION
Closes #653 

In #653, the user reports that the following usage of glog API:
```cpp
google::SetLogDestination(google::INFO, ".");
google::EnableLogCleaner(1);
```

will lead to an uncaught out_of_range exception.
```
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::at: __n (which is 18446744073709551615) >= this->size() (which is 0)
[1]    835009 abort (core dumped)  ./out
```

This is caused by a bug in `LogCleaner::Run()` where `base_filename` doesn't end with a "/".
https://github.com/google/glog/blob/0b3d4cb471e36d8e677e75e4e8d0345e7bf2a418/src/logging.cc#L1334-L1335

This PR:
1. checks if `base_filename` in `LogCleaner::Run()` ends with a "/", and if not, then we simply pass the relative path to `LogCleaner::GetOverdueLogNames()`.
2. In `LogCleaner::GetOverdueLogNames`, we only concatenate `log_directory` and `ent->d_name` if `log_directory` ends with a "/". Otherwise, just pass the relative path to `LogCleaner::IsLogFromCurrentProject`.
3. Some trivial changes to improve the readability of source code