### PR TITLE
Fix unwind detection on FreeBSD/powerpc64

### DIFF
--- a/cmake/FindUnwind.cmake
+++ b/cmake/FindUnwind.cmake
@@ -19,7 +19,8 @@ elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
     set (Unwind_ARCH "x86_64")
 elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
     set (Unwind_ARCH "x86")
-elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc64")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc64" OR
+        CMAKE_SYSTEM_PROCESSOR MATCHES "^powerpc64")
     set (Unwind_ARCH "ppc64")
 elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc")
     set (Unwind_ARCH "ppc32")


### PR DESCRIPTION
Linux uses name "ppc64", but FreeBSD uses "powerpc64".