### PR TITLE
Export COPYING

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,7 @@
 licenses(['notice'])
 
+exports_files(["COPYING"])
+
 load(':bazel/glog.bzl', 'glog_library')
 
 glog_library()


### PR DESCRIPTION
By exporting `COPYING`, Bazel projects depending on glog can easily access its license.