### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,32 +1,23 @@
 ---
 platforms:
-  ubuntu1604:
-    build_flags:
-    - "--features=layering_check"
-    build_targets:
-    - "..."
-    test_flags:
-    - "--features=layering_check"
-    test_targets:
-    - "..."
   ubuntu1804:
     build_flags:
     - "--features=layering_check"
     build_targets:
-    - "..."
+    - "//..."
     test_flags:
     - "--features=layering_check"
     test_targets:
-    - "..."
+    - "//..."
   macos:
     build_flags:
     - "--features=layering_check"
     build_targets:
-    - "..."
+    - "//..."
     test_flags:
     - "--features=layering_check"
     test_targets:
-    - "..."
+    - "//..."
   windows:
     # Optional: use VS 2017 instead of 2015.
     environment:
@@ -34,8 +25,8 @@ platforms:
     build_flags:
     - "--features=layering_check"
     build_targets:
-    - "..."
+    - "//..."
     test_flags:
     - "--features=layering_check"
     test_targets:
-    - "..."
+    - "//..."


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.