### PR TITLE
Fix syscall deprecation warning on macOS >= 10.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,11 @@ check_cxx_compiler_flag (-Wdeprecated HAVE_NO_DEPRECATED)
 check_cxx_compiler_flag (-Wunnamed-type-template-args
     HAVE_NO_UNNAMED_TYPE_TEMPLATE_ARGS)
 
+cmake_push_check_state (RESET)
+set (CMAKE_REQUIRED_LIBRARIES Threads::Threads)
+check_cxx_symbol_exists (pthread_threadid_np "pthread.h" HAVE_PTHREAD_THREADID_NP)
+cmake_pop_check_state ()
+
 # NOTE: Cannot use check_function_exists here since >=vc-14.0 can define
 # snprintf as an inline function
 check_cxx_symbol_exists (snprintf cstdio HAVE_SNPRINTF)

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -222,4 +222,7 @@
 
 #endif
 
+/* Replacement for deprecated syscall(SYS_gettid) on macOS. */
+#cmakedefine HAVE_PTHREAD_THREADID_NP ${HAVE_PTHREAD_THREADID_NP}
+
 #endif  // GLOG_CONFIG_H

--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -59,7 +59,7 @@
 # include <unistd.h>
 #endif
 
-#if defined(HAVE_SYSCALL_H) || defined(HAVE_SYS_SYSCALL_H)
+#if (defined(HAVE_SYSCALL_H) || defined(HAVE_SYS_SYSCALL_H)) && (!(defined(OS_MACOSX)))
 # define safe_write(fd, s, len)  syscall(SYS_write, fd, s, len)
 #else
   // Not so safe, but what can you do?

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -248,7 +248,13 @@ pid_t GetTID() {
 #endif
   static bool lacks_gettid = false;
   if (!lacks_gettid) {
+#if (defined(OS_MACOSX) && defined(HAVE_PTHREAD_THREADID_NP))
+    uint64_t tid64;
+    const int error = pthread_threadid_np(NULL, &tid64);
+    pid_t tid = error ? -1 : (pid_t)tid64;
+#else
     pid_t tid = syscall(__NR_gettid);
+#endif
     if (tid != -1) {
       return tid;
     }


### PR DESCRIPTION
Fix #185 
