### PR TITLE
Change size type in AnnotateBenignRaceSized to size_t from long

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1034,7 +1034,7 @@ extern "C" void AnnotateBenignRaceSized(
   const char *file,
   int line,
   const volatile void *mem,
-  long size,
+  size_t size,
   const char *description);
 
 namespace google {


### PR DESCRIPTION
This makes this definition consistent with Abseil's declarations.  See:
https://github.com/abseil/abseil-cpp/blob/master/absl/base/dynamic_annotations.h#L213-L215

Having this unsigned seems to match what libsanitizers is expecting:
https://github.com/gcc-mirror/gcc/blob/16e2427f50c208dfe07d07f18009969502c25dc8/libsanitizer/tsan/tsan_interface_ann.cpp#L367-L371

This solves a "conflicting declaration of C function" when using glog
with abseil.