### PR TITLE
Fix link error for Emscripten

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -2148,6 +2148,7 @@ static string ShellEscape(const string& src) {
 // log_mutex.
 static bool SendEmailInternal(const char*dest, const char *subject,
                               const char*body, bool use_logging) {
+#ifdef __USE_POSIX2
   if (dest && *dest) {
     if ( use_logging ) {
       VLOG(1) << "Trying to send TITLE:" << subject
@@ -2190,6 +2191,7 @@ static bool SendEmailInternal(const char*dest, const char *subject,
       }
     }
   }
+#endif
   return false;
 }
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -2148,7 +2148,7 @@ static string ShellEscape(const string& src) {
 // log_mutex.
 static bool SendEmailInternal(const char*dest, const char *subject,
                               const char*body, bool use_logging) {
-#ifdef __USE_POSIX2
+#ifndef __EMSCRIPTEN__
   if (dest && *dest) {
     if ( use_logging ) {
       VLOG(1) << "Trying to send TITLE:" << subject


### PR DESCRIPTION
This PR fixes a build error below by changing `SendEmailInternal` into noop if `__EMSCRIPTEN__` is defined.
`wasm-ld: error: bazel-out/wasm-fastbuild-ST-8c7d4a846ea3/bin/external/com_github_glog_glog/libglog.a(logging.o): undefined symbol: popen`