### PR TITLE
`raw_logging.h` depends on type definition in `logging.h`.

### DIFF
--- a/src/glog/raw_logging.h.in
+++ b/src/glog/raw_logging.h.in
@@ -41,6 +41,7 @@
 @ac_google_start_namespace@
 
 #include "glog/log_severity.h"
+#include "glog/logging.h"
 #include "glog/vlog_is_on.h"
 
 // Annoying stuff for windows -- makes sure clients can import these functions


### PR DESCRIPTION
Resolve https://github.com/google/glog/issues/712