### PR TITLE
export `OS_*` defines (fixes #715)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,3 @@
-/*.cmake
-/*.filters
-/*.sln
-/*.vcxproj
-autom4te.cache
+*.orig
+/build*/
 bazel-*
-CMakeCache.txt
-CMakeFiles/
-config.h
-glog-*.tar.gz
-packages/debian-*
-packages/rpm-unknown

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,7 @@ set (GLOG_PUBLIC_H
   ${CMAKE_CURRENT_BINARY_DIR}/glog/stl_logging.h
   ${CMAKE_CURRENT_BINARY_DIR}/glog/vlog_is_on.h
   src/glog/log_severity.h
+  src/glog/platform.h
 )
 
 set (GLOG_SRCS

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -140,6 +140,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         }),
         hdrs = [
                 "src/glog/log_severity.h",
+                "src/glog/platform.h",
                 ":logging_h",
                 ":raw_logging_h",
                 ":stl_logging_h",
@@ -149,7 +150,10 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         defines = select({
             # GOOGLE_GLOG_DLL_DECL is normally set by export.h, but that's not
             # generated for Bazel.
-            "@bazel_tools//src/conditions:windows": ["GOOGLE_GLOG_DLL_DECL=__declspec(dllexport)"],
+            "@bazel_tools//src/conditions:windows": [
+                "GOOGLE_GLOG_DLL_DECL=__declspec(dllexport)",
+                "GLOG_NO_ABBREVIATED_SEVERITIES",
+            ],
             "//conditions:default": [],
         }),
         copts =

--- a/src/base/commandlineflags.h
+++ b/src/base/commandlineflags.h
@@ -59,7 +59,7 @@
 
 #else
 
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 #define DECLARE_VARIABLE(type, shorttype, name, tn)                     \
   namespace fL##shorttype {                                             \

--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -39,13 +39,13 @@
 #include "demangle.h"
 #include "utilities.h"
 
-#if defined(OS_WINDOWS)
+#if defined(GLOG_OS_WINDOWS)
 #include <dbghelp.h>
 #endif
 
 _START_GOOGLE_NAMESPACE_
 
-#if !defined(OS_WINDOWS)
+#if !defined(GLOG_OS_WINDOWS)
 typedef struct {
   const char *abbrev;
   const char *real_name;
@@ -1324,7 +1324,7 @@ static bool ParseTopLevelMangledName(State *state) {
 
 // The demangler entry point.
 bool Demangle(const char *mangled, char *out, size_t out_size) {
-#if defined(OS_WINDOWS)
+#if defined(GLOG_OS_WINDOWS)
   // When built with incremental linking, the Windows debugger
   // library provides a more complicated `Symbol->Name` with the
   // Incremental Linking Table offset, which looks like

--- a/src/demangle.h
+++ b/src/demangle.h
@@ -71,7 +71,7 @@
 #define BASE_DEMANGLE_H_
 
 #include "config.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 _START_GOOGLE_NAMESPACE_
 

--- a/src/demangle_unittest.cc
+++ b/src/demangle_unittest.cc
@@ -36,7 +36,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "demangle.h"
 #include "googletest.h"
 #include "config.h"
@@ -62,7 +62,7 @@ static const char *DemangleIt(const char * const mangled) {
   }
 }
 
-#if defined(OS_WINDOWS)
+#if defined(GLOG_OS_WINDOWS)
 
 TEST(Demangle, Windows) {
   EXPECT_STREQ(

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -63,8 +63,10 @@
 #define GLOG_MSVC_POP_WARNING()
 #endif
 
+#include <glog/platform.h>
+
 #if @ac_cv_have_glog_export@
-#include "glog/export.h"
+#include <glog/export.h>
 #endif
 
 // Annoying stuff for windows -- makes sure clients can import these functions
@@ -106,7 +108,7 @@
 
 #if @ac_cv_cxx11_atomic@ && __cplusplus >= 201103L
 #include <atomic>
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
 #include <Windows.h>
 #endif
 
@@ -586,8 +588,8 @@ DECLARE_bool(log_utc_time);
 @ac_google_start_namespace@
 
 // They need the definitions of integer types.
-#include "glog/log_severity.h"
-#include "glog/vlog_is_on.h"
+#include <glog/log_severity.h>
+#include <glog/vlog_is_on.h>
 
 // Initialize google's logging library. You will see the program name
 // specified by argv0 in log outputs.
@@ -1055,7 +1057,7 @@ namespace google {
     LOG_PREVIOUS_TIME_RAW.store(std::chrono::duration_cast<std::chrono::nanoseconds>(LOG_CURRENT_TIME).count(), std::memory_order_relaxed); \
   if (LOG_TIME_DELTA > LOG_TIME_PERIOD) @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity).stream()
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
 #define SOME_KIND_OF_LOG_EVERY_T(severity, seconds) \
   GLOG_CONSTEXPR LONGLONG LOG_TIME_PERIOD = (seconds) * LONGLONG(1000000000); \
   static LARGE_INTEGER LOG_PREVIOUS_TIME; \
@@ -1131,7 +1133,7 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
 
 #define SOME_KIND_OF_LOG_EVERY_N(severity, n, what_to_do) \
   static volatile unsigned LOG_OCCURRENCES = 0; \

--- a/src/glog/platform.h
+++ b/src/glog/platform.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2007, Google Inc.
+// Copyright (c) 2008, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -27,47 +27,32 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Author: Sergey Ioffe
+// Author: Shinichiro Hamaji
+//
+// Detect supported platforms.
 
-// The common part of the striplog tests.
+#ifndef GLOG_PLATFORM_H
+#define GLOG_PLATFORM_H
 
-#include <cstdio>
-#include <string>
-#include <iosfwd>
-#include <glog/logging.h>
-#include "base/commandlineflags.h"
-#include "config.h"
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
+#define GLOG_OS_WINDOWS
+#elif defined(__CYGWIN__) || defined(__CYGWIN32__)
+#define GLOG_OS_CYGWIN
+#elif defined(linux) || defined(__linux) || defined(__linux__)
+#ifndef GLOG_OS_LINUX
+#define GLOG_OS_LINUX
+#endif
+#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
+#define GLOG_OS_MACOSX
+#elif defined(__FreeBSD__)
+#define GLOG_OS_FREEBSD
+#elif defined(__NetBSD__)
+#define GLOG_OS_NETBSD
+#elif defined(__OpenBSD__)
+#define GLOG_OS_OPENBSD
+#else
+// TODO(hamaji): Add other platforms.
+#error Platform not supported by glog. Please consider to contribute platform information by submitting a pull request on Github.
+#endif
 
-DECLARE_bool(logtostderr);
-GLOG_DEFINE_bool(check_mode, false, "Prints 'opt' or 'dbg'");
-
-using std::string;
-using namespace GOOGLE_NAMESPACE;
-
-int CheckNoReturn(bool b) {
-  string s;
-  if (b) {
-    LOG(FATAL) << "Fatal";
-  } else {
-    return 0;
-  }
-}
-
-struct A { };
-std::ostream &operator<<(std::ostream &str, const A&) {return str;}
-
-int main(int, char* argv[]) {
-  FLAGS_logtostderr = true;
-  InitGoogleLogging(argv[0]);
-  if (FLAGS_check_mode) {
-    printf("%s\n", DEBUG_MODE ? "dbg" : "opt");
-    return 0;
-  }
-  LOG(INFO) << "TESTMESSAGE INFO";
-  LOG(WARNING) << 2 << "something" << "TESTMESSAGE WARNING"
-               << 1 << 'c' << A() << std::endl;
-  LOG(ERROR) << "TESTMESSAGE ERROR";
-  bool flag = true;
-  (flag ? LOG(INFO) : LOG(ERROR)) << "TESTMESSAGE COND";
-  LOG(FATAL) << "TESTMESSAGE FATAL";
-}
+#endif // GLOG_PLATFORM_H

--- a/src/glog/raw_logging.h.in
+++ b/src/glog/raw_logging.h.in
@@ -40,9 +40,9 @@
 
 @ac_google_start_namespace@
 
-#include "glog/log_severity.h"
-#include "glog/logging.h"
-#include "glog/vlog_is_on.h"
+#include <glog/log_severity.h>
+#include <glog/logging.h>
+#include <glog/vlog_is_on.h>
 
 // Annoying stuff for windows -- makes sure clients can import these functions
 #ifndef GOOGLE_GLOG_DLL_DECL

--- a/src/glog/vlog_is_on.h.in
+++ b/src/glog/vlog_is_on.h.in
@@ -61,7 +61,7 @@
 #ifndef BASE_VLOG_IS_ON_H_
 #define BASE_VLOG_IS_ON_H_
 
-#include "glog/log_severity.h"
+#include <glog/log_severity.h>
 
 // Annoying stuff for windows -- makes sure clients can import these functions
 #ifndef GOOGLE_GLOG_DLL_DECL

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -76,7 +76,7 @@ _END_GOOGLE_NAMESPACE_
 #define GOOGLE_GLOG_DLL_DECL
 
 static inline string GetTempDir() {
-#ifndef OS_WINDOWS
+#ifndef GLOG_OS_WINDOWS
   return "/tmp";
 #else
   char tmp[MAX_PATH];
@@ -85,7 +85,7 @@ static inline string GetTempDir() {
 #endif
 }
 
-#if defined(OS_WINDOWS) && defined(_MSC_VER) && !defined(TEST_SRC_DIR)
+#if defined(GLOG_OS_WINDOWS) && defined(_MSC_VER) && !defined(TEST_SRC_DIR)
 // The test will run in glog/vsproject/<project name>
 // (e.g., glog/vsproject/logging_unittest).
 static const char TEST_SRC_DIR[] = "../..";
@@ -220,7 +220,7 @@ static inline void CalledAbort() {
   longjmp(g_jmp_buf, 1);
 }
 
-#ifdef OS_WINDOWS
+#ifdef GLOG_OS_WINDOWS
 // TODO(hamaji): Death test somehow doesn't work in Windows.
 #define ASSERT_DEATH(fn, msg)
 #else
@@ -510,7 +510,7 @@ static inline bool MungeAndDiffTestStderr(const string& golden_filename) {
     WriteToFile(golden, munged_golden);
     string munged_captured = cap->filename() + ".munged";
     WriteToFile(captured, munged_captured);
-#ifdef OS_WINDOWS
+#ifdef GLOG_OS_WINDOWS
     string diffcmd("fc " + munged_golden + " " + munged_captured);
 #else
     string diffcmd("diff -u " + munged_golden + " " + munged_captured);
@@ -552,7 +552,7 @@ class Thread {
   virtual ~Thread() {}
 
   void SetJoinable(bool) {}
-#if defined(OS_WINDOWS) && !defined(OS_CYGWIN)
+#if defined(GLOG_OS_WINDOWS) && !defined(GLOG_OS_CYGWIN)
   void Start() {
     handle_ = CreateThread(NULL,
                            0,
@@ -585,7 +585,7 @@ class Thread {
     return NULL;
   }
 
-#if defined(OS_WINDOWS) && !defined(OS_CYGWIN)
+#if defined(GLOG_OS_WINDOWS) && !defined(GLOG_OS_CYGWIN)
   static DWORD InvokeThreadW(void* self) {
     InvokeThread(self);
     return 0;
@@ -598,7 +598,7 @@ class Thread {
 };
 
 static inline void SleepForMilliseconds(unsigned t) {
-#ifndef OS_WINDOWS
+#ifndef GLOG_OS_WINDOWS
 # if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 199309L
   const struct timespec req = {0, t * 1000 * 1000};
   nanosleep(&req, NULL);

--- a/src/logging_custom_prefix_unittest.cc
+++ b/src/logging_custom_prefix_unittest.cc
@@ -56,8 +56,8 @@
 #include <stdlib.h>
 
 #include "base/commandlineflags.h"
-#include "glog/logging.h"
-#include "glog/raw_logging.h"
+#include <glog/logging.h>
+#include <glog/raw_logging.h>
 #include "googletest.h"
 
 DECLARE_string(log_backtrace_at);  // logging.cc
@@ -592,7 +592,7 @@ void TestCHECK() {
 
   // Tests using CHECK*() on anonymous enums.
   // Apple's GCC doesn't like this.
-#if !defined(OS_MACOSX)
+#if !defined(GLOG_OS_MACOSX)
   CHECK_EQ(CASE_A, CASE_A);
   CHECK_NE(CASE_A, CASE_B);
   CHECK_GE(CASE_A, CASE_A);
@@ -674,7 +674,7 @@ static void GetFiles(const string& pattern, vector<string>* files) {
     files->push_back(string(g.gl_pathv[i]));
   }
   globfree(&g);
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
   WIN32_FIND_DATAA data;
   HANDLE handle = FindFirstFileA(pattern.c_str(), &data);
   size_t index = pattern.rfind('\\');
@@ -803,7 +803,7 @@ static void TestTwoProcessesWrite() {
 }
 
 static void TestSymlink() {
-#ifndef OS_WINDOWS
+#ifndef GLOG_OS_WINDOWS
   fprintf(stderr, "==== Test setting log file symlink\n");
   string dest = FLAGS_test_tmpdir + "/logging_test_symlink";
   string sym = FLAGS_test_tmpdir + "/symlinkbase";
@@ -946,7 +946,7 @@ static void TestTruncate() {
   // MacOSX 10.4 doesn't fail in this case.
   // Windows doesn't have symlink.
   // Let's just ignore this test for these cases.
-#if !defined(OS_MACOSX) && !defined(OS_WINDOWS)
+#if !defined(GLOG_OS_MACOSX) && !defined(GLOG_OS_WINDOWS)
   // Through a symlink should fail to truncate
   string linkname = path + ".link";
   unlink(linkname.c_str());
@@ -955,7 +955,7 @@ static void TestTruncate() {
 #endif
 
   // The /proc/self path makes sense only for linux.
-#if defined(OS_LINUX)
+#if defined(GLOG_OS_LINUX)
   // Through an open fd symlink should work
   int fd;
   CHECK_ERR(fd = open(path.c_str(), O_APPEND | O_WRONLY));
@@ -1211,7 +1211,7 @@ TEST(Strerror, logging) {
   CHECK_EQ(posix_strerror_r(errcode, buf, 0), -1);
   CHECK_EQ(buf[0], 'A');
   CHECK_EQ(posix_strerror_r(errcode, NULL, buf_size), -1);
-#if defined(OS_MACOSX) || defined(OS_FREEBSD) || defined(OS_OPENBSD)
+#if defined(GLOG_OS_MACOSX) || defined(GLOG_OS_FREEBSD) || defined(GLOG_OS_OPENBSD)
   // MacOSX or FreeBSD considers this case is an error since there is
   // no enough space.
   CHECK_EQ(posix_strerror_r(errcode, buf, 1), -1);

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -56,8 +56,8 @@
 #include <vector>
 
 #include "base/commandlineflags.h"
-#include "glog/logging.h"
-#include "glog/raw_logging.h"
+#include <glog/logging.h>
+#include <glog/raw_logging.h>
 #include "googletest.h"
 
 DECLARE_string(log_backtrace_at);  // logging.cc
@@ -587,7 +587,7 @@ void TestCHECK() {
 
   // Tests using CHECK*() on anonymous enums.
   // Apple's GCC doesn't like this.
-#if !defined(OS_MACOSX)
+#if !defined(GLOG_OS_MACOSX)
   CHECK_EQ(CASE_A, CASE_A);
   CHECK_NE(CASE_A, CASE_B);
   CHECK_GE(CASE_A, CASE_A);
@@ -669,7 +669,7 @@ static void GetFiles(const string& pattern, vector<string>* files) {
     files->push_back(string(g.gl_pathv[i]));
   }
   globfree(&g);
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
   WIN32_FIND_DATAA data;
   HANDLE handle = FindFirstFileA(pattern.c_str(), &data);
   size_t index = pattern.rfind('\\');
@@ -798,7 +798,7 @@ static void TestTwoProcessesWrite() {
 }
 
 static void TestSymlink() {
-#ifndef OS_WINDOWS
+#ifndef GLOG_OS_WINDOWS
   fprintf(stderr, "==== Test setting log file symlink\n");
   string dest = FLAGS_test_tmpdir + "/logging_test_symlink";
   string sym = FLAGS_test_tmpdir + "/symlinkbase";
@@ -941,7 +941,7 @@ static void TestTruncate() {
   // MacOSX 10.4 doesn't fail in this case.
   // Windows doesn't have symlink.
   // Let's just ignore this test for these cases.
-#if !defined(OS_MACOSX) && !defined(OS_WINDOWS)
+#if !defined(GLOG_OS_MACOSX) && !defined(GLOG_OS_WINDOWS)
   // Through a symlink should fail to truncate
   string linkname = path + ".link";
   unlink(linkname.c_str());
@@ -950,7 +950,7 @@ static void TestTruncate() {
 #endif
 
   // The /proc/self path makes sense only for linux.
-#if defined(OS_LINUX)
+#if defined(GLOG_OS_LINUX)
   // Through an open fd symlink should work
   int fd;
   CHECK_ERR(fd = open(path.c_str(), O_APPEND | O_WRONLY));
@@ -1031,7 +1031,7 @@ int64 elapsedTime_ns(const std::chrono::steady_clock::time_point& begin,
   return std::chrono::duration_cast<std::chrono::nanoseconds>((end - begin))
           .count();
 }
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
 struct LogTimeRecorder {
   LogTimeRecorder() : m_streamTimes(0) {}
   size_t m_streamTimes;
@@ -1299,7 +1299,7 @@ TEST(Strerror, logging) {
   CHECK_EQ(posix_strerror_r(errcode, buf, 0), -1);
   CHECK_EQ(buf[0], 'A');
   CHECK_EQ(posix_strerror_r(errcode, NULL, buf_size), -1);
-#if defined(OS_MACOSX) || defined(OS_FREEBSD) || defined(OS_OPENBSD)
+#if defined(GLOG_OS_MACOSX) || defined(GLOG_OS_FREEBSD) || defined(GLOG_OS_OPENBSD)
   // MacOSX or FreeBSD considers this case is an error since there is
   // no enough space.
   CHECK_EQ(posix_strerror_r(errcode, buf, 1), -1);

--- a/src/mock-log.h
+++ b/src/mock-log.h
@@ -42,7 +42,7 @@
 
 #include <gmock/gmock.h>
 
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 _START_GOOGLE_NAMESPACE_
 namespace glog_testing {

--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -42,8 +42,8 @@
 #include <fcntl.h>                 // for open()
 #include <ctime>
 #include "config.h"
-#include "glog/logging.h"          // To pick up flag settings etc.
-#include "glog/raw_logging.h"
+#include <glog/logging.h>          // To pick up flag settings etc.
+#include <glog/raw_logging.h>
 #include "base/commandlineflags.h"
 
 #ifdef HAVE_STACKTRACE
@@ -59,7 +59,7 @@
 # include <unistd.h>
 #endif
 
-#if (defined(HAVE_SYSCALL_H) || defined(HAVE_SYS_SYSCALL_H)) && (!(defined(OS_MACOSX)))
+#if (defined(HAVE_SYSCALL_H) || defined(HAVE_SYS_SYSCALL_H)) && (!(defined(GLOG_OS_MACOSX)))
 # define safe_write(fd, s, len)  syscall(SYS_write, fd, s, len)
 #else
   // Not so safe, but what can you do?

--- a/src/signalhandler_unittest.cc
+++ b/src/signalhandler_unittest.cc
@@ -41,7 +41,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 #ifdef HAVE_LIB_GFLAGS
 #include <gflags/gflags.h>

--- a/src/stacktrace.h
+++ b/src/stacktrace.h
@@ -34,7 +34,7 @@
 #define BASE_STACKTRACE_H_
 
 #include "config.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 _START_GOOGLE_NAMESPACE_
 

--- a/src/stacktrace_libunwind-inl.h
+++ b/src/stacktrace_libunwind-inl.h
@@ -37,7 +37,7 @@ extern "C" {
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 }
-#include "glog/raw_logging.h"
+#include <glog/raw_logging.h>
 #include "stacktrace.h"
 
 _START_GOOGLE_NAMESPACE_

--- a/src/stacktrace_unittest.cc
+++ b/src/stacktrace_unittest.cc
@@ -33,7 +33,7 @@
 #include <cstdlib>
 #include "config.h"
 #include "base/commandlineflags.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "stacktrace.h"
 
 #ifdef HAVE_EXECINFO_H

--- a/src/stacktrace_x86-inl.h
+++ b/src/stacktrace_x86-inl.h
@@ -33,7 +33,7 @@
 
 #include "utilities.h"   // for OS_* macros
 
-#if !defined(OS_WINDOWS)
+#if !defined(GLOG_OS_WINDOWS)
 #include <unistd.h>
 #include <sys/mman.h>
 #endif
@@ -74,7 +74,7 @@ static void **NextStackFrame(void **old_sp) {
   // last two pages in the address space
   if ((uintptr_t)new_sp >= 0xffffe000) return NULL;
 #endif
-#if !defined(OS_WINDOWS)
+#if !defined(GLOG_OS_WINDOWS)
   if (!STRICT_UNWINDING) {
     // Lax sanity checks cause a crash in 32-bit tcmalloc/crash_reason_test
     // on AMD-based machines with VDSO-enabled kernels.

--- a/src/stl_logging_unittest.cc
+++ b/src/stl_logging_unittest.cc
@@ -58,8 +58,8 @@
 # endif
 #endif
 
-#include "glog/logging.h"
-#include "glog/stl_logging.h"
+#include <glog/logging.h>
+#include <glog/stl_logging.h>
 #include "googletest.h"
 
 using namespace std;

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -46,7 +46,7 @@
 // and memmove().  We assume they are async-signal-safe.
 //
 // Additional header can be specified by the GLOG_BUILD_CONFIG_INCLUDE
-// macro to add platform specific defines (e.g. OS_OPENBSD).
+// macro to add platform specific defines (e.g. GLOG_OS_OPENBSD).
 
 #ifdef GLOG_BUILD_CONFIG_INCLUDE
 #include GLOG_BUILD_CONFIG_INCLUDE
@@ -113,7 +113,7 @@ _END_GOOGLE_NAMESPACE_
 #if defined(HAVE_DLFCN_H)
 #include <dlfcn.h>
 #endif
-#if defined(OS_OPENBSD)
+#if defined(GLOG_OS_OPENBSD)
 #include <sys/exec_elf.h>
 #else
 #include <elf.h>
@@ -132,7 +132,7 @@ _END_GOOGLE_NAMESPACE_
 
 #include "symbolize.h"
 #include "config.h"
-#include "glog/raw_logging.h"
+#include <glog/raw_logging.h>
 
 // Re-runs fn until it doesn't cause EINTR.
 #define NO_INTR(fn)   do {} while ((fn) < 0 && errno == EINTR)
@@ -847,7 +847,7 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
 
 _END_GOOGLE_NAMESPACE_
 
-#elif defined(OS_MACOSX) && defined(HAVE_DLADDR)
+#elif defined(GLOG_OS_MACOSX) && defined(HAVE_DLADDR)
 
 #include <dlfcn.h>
 #include <cstring>
@@ -872,7 +872,7 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
 
 _END_GOOGLE_NAMESPACE_
 
-#elif defined(OS_WINDOWS) || defined(OS_CYGWIN)
+#elif defined(GLOG_OS_WINDOWS) || defined(GLOG_OS_CYGWIN)
 
 #include <windows.h>
 #include <dbghelp.h>

--- a/src/symbolize.h
+++ b/src/symbolize.h
@@ -56,7 +56,7 @@
 
 #include "utilities.h"
 #include "config.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 #ifdef HAVE_SYMBOLIZE
 

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -35,7 +35,7 @@
 #include <iostream>
 
 #include "config.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "googletest.h"
 #include "symbolize.h"
 #include "utilities.h"
@@ -52,7 +52,7 @@ using namespace GOOGLE_NAMESPACE;
 
 #define always_inline
 
-#if defined(__ELF__) || defined(OS_WINDOWS) || defined(OS_CYGWIN)
+#if defined(__ELF__) || defined(GLOG_OS_WINDOWS) || defined(GLOG_OS_CYGWIN)
 // A wrapper function for Symbolize() to make the unit test simple.
 static const char *TrySymbolize(void *pc) {
   static char symbol[4096];
@@ -360,7 +360,7 @@ static void ATTRIBUTE_NOINLINE TestWithReturnAddress() {
 #endif
 }
 
-# elif defined(OS_WINDOWS) || defined(OS_CYGWIN)
+# elif defined(GLOG_OS_WINDOWS) || defined(GLOG_OS_CYGWIN)
 
 #ifdef _MSC_VER
 #include <intrin.h>
@@ -412,10 +412,10 @@ int main(int argc, char **argv) {
   TestWithPCInsideNonInlineFunction();
   TestWithReturnAddress();
   return RUN_ALL_TESTS();
-# elif defined(OS_WINDOWS) || defined(OS_CYGWIN)
+# elif defined(GLOG_OS_WINDOWS) || defined(GLOG_OS_CYGWIN)
   TestWithReturnAddress();
   return RUN_ALL_TESTS();
-# else  // OS_WINDOWS
+# else  // GLOG_OS_WINDOWS
   printf("PASS (no symbolize_unittest support)\n");
   return 0;
 # endif  // __ELF__

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -161,7 +161,7 @@ static void DumpStackTraceAndExit() {
     sigemptyset(&sig_action.sa_mask);
     sig_action.sa_handler = SIG_DFL;
     sigaction(SIGABRT, &sig_action, NULL);
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
     signal(SIGABRT, SIG_DFL);
 #endif  // HAVE_SIGACTION
   }
@@ -186,7 +186,7 @@ const char* ProgramInvocationShortName() {
   }
 }
 
-#ifdef OS_WINDOWS
+#ifdef GLOG_OS_WINDOWS
 struct timeval {
   long tv_sec, tv_usec;
 };
@@ -249,9 +249,9 @@ bool PidHasChanged() {
 
 pid_t GetTID() {
   // On Linux and MacOSX, we try to use gettid().
-#if defined OS_LINUX || defined OS_MACOSX
+#if defined GLOG_OS_LINUX || defined GLOG_OS_MACOSX
 #ifndef __NR_gettid
-#ifdef OS_MACOSX
+#ifdef GLOG_OS_MACOSX
 #define __NR_gettid SYS_gettid
 #elif ! defined __i386__
 #error "Must define __NR_gettid for non-x86 platforms"
@@ -261,7 +261,7 @@ pid_t GetTID() {
 #endif
   static bool lacks_gettid = false;
   if (!lacks_gettid) {
-#if (defined(OS_MACOSX) && defined(HAVE_PTHREAD_THREADID_NP))
+#if (defined(GLOG_OS_MACOSX) && defined(HAVE_PTHREAD_THREADID_NP))
     uint64_t tid64;
     const int error = pthread_threadid_np(NULL, &tid64);
     pid_t tid = error ? -1 : static_cast<pid_t>(tid64);
@@ -277,12 +277,12 @@ pid_t GetTID() {
     // the value change to "true".
     lacks_gettid = true;
   }
-#endif  // OS_LINUX || OS_MACOSX
+#endif  // GLOG_OS_LINUX || GLOG_OS_MACOSX
 
   // If gettid() could not be used, we use one of the following.
-#if defined OS_LINUX
+#if defined GLOG_OS_LINUX
   return getpid();  // Linux:  getpid returns thread ID when gettid is absent
-#elif defined OS_WINDOWS && !defined OS_CYGWIN
+#elif defined GLOG_OS_WINDOWS && !defined GLOG_OS_CYGWIN
   return GetCurrentThreadId();
 #elif defined(HAVE_PTHREAD)
   // If none of the techniques above worked, we use pthread_self().
@@ -294,7 +294,7 @@ pid_t GetTID() {
 
 const char* const_basename(const char* filepath) {
   const char* base = strrchr(filepath, '/');
-#ifdef OS_WINDOWS  // Look for either path separator in Windows
+#ifdef GLOG_OS_WINDOWS  // Look for either path separator in Windows
   if (!base)
     base = strrchr(filepath, '\\');
 #endif
@@ -307,7 +307,7 @@ const string& MyUserName() {
 }
 static void MyUserNameInitializer() {
   // TODO(hamaji): Probably this is not portable.
-#if defined(OS_WINDOWS)
+#if defined(GLOG_OS_WINDOWS)
   const char* user = getenv("USERNAME");
 #else
   const char* user = getenv("USER");
@@ -356,7 +356,7 @@ void InitGoogleLoggingUtilities(const char* argv0) {
   CHECK(!IsGoogleLoggingInitialized())
       << "You called InitGoogleLogging() twice!";
   const char* slash = strrchr(argv0, '/');
-#ifdef OS_WINDOWS
+#ifdef GLOG_OS_WINDOWS
   if (!slash)  slash = strrchr(argv0, '\\');
 #endif
   g_program_invocation_short_name = slash ? slash + 1 : argv0;

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -34,26 +34,6 @@
 #ifndef UTILITIES_H__
 #define UTILITIES_H__
 
-#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__)
-# define OS_WINDOWS
-#elif defined(__CYGWIN__) || defined(__CYGWIN32__)
-# define OS_CYGWIN
-#elif defined(linux) || defined(__linux) || defined(__linux__)
-# ifndef OS_LINUX
-#  define OS_LINUX
-# endif
-#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
-# define OS_MACOSX
-#elif defined(__FreeBSD__)
-# define OS_FREEBSD
-#elif defined(__NetBSD__)
-# define OS_NETBSD
-#elif defined(__OpenBSD__)
-# define OS_OPENBSD
-#else
-// TODO(hamaji): Add other platforms.
-#endif
-
 // printf macros for size_t, in the style of inttypes.h
 #ifdef _LP64
 #define __PRIS_PREFIX "z"
@@ -76,12 +56,13 @@
 
 #include <string>
 
-#if defined(OS_WINDOWS)
+#include <glog/logging.h>
+
+#if defined(GLOG_OS_WINDOWS)
 # include "port.h"
 #endif
 
 #include "config.h"
-#include "glog/logging.h"
 
 // There are three different ways we can try to get the stack trace:
 //
@@ -114,7 +95,7 @@
 #  define STACKTRACE_H "stacktrace_x86_64-inl.h"
 # elif (defined(__ppc__) || defined(__PPC__)) && __GNUC__ >= 2
 #  define STACKTRACE_H "stacktrace_powerpc-inl.h"
-# elif defined(OS_WINDOWS)
+# elif defined(GLOG_OS_WINDOWS)
 #  define STACKTRACE_H "stacktrace_windows-inl.h"
 # endif
 #endif
@@ -130,12 +111,12 @@
 #ifndef GLOG_NO_SYMBOLIZE_DETECTION
 #ifndef HAVE_SYMBOLIZE
 // defined by gcc
-#if defined(__ELF__) && defined(OS_LINUX)
+#if defined(__ELF__) && defined(GLOG_OS_LINUX)
 # define HAVE_SYMBOLIZE
-#elif defined(OS_MACOSX) && defined(HAVE_DLADDR)
+#elif defined(GLOG_OS_MACOSX) && defined(HAVE_DLADDR)
 // Use dladdr to symbolize.
 # define HAVE_SYMBOLIZE
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
 // Use DbgHelp to symbolize
 # define HAVE_SYMBOLIZE
 #endif
@@ -154,7 +135,7 @@ namespace glog_internal_namespace_ {
 #ifdef HAVE___ATTRIBUTE__
 # define ATTRIBUTE_NOINLINE __attribute__ ((noinline))
 # define HAVE_ATTRIBUTE_NOINLINE
-#elif defined(OS_WINDOWS)
+#elif defined(GLOG_OS_WINDOWS)
 # define ATTRIBUTE_NOINLINE __declspec(noinline)
 # define HAVE_ATTRIBUTE_NOINLINE
 #else

--- a/src/utilities_unittest.cc
+++ b/src/utilities_unittest.cc
@@ -30,7 +30,7 @@
 // Author: Shinichiro Hamaji
 #include "utilities.h"
 #include "googletest.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 #ifdef HAVE_LIB_GFLAGS
 #include <gflags/gflags.h>

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -40,8 +40,8 @@
 #include <cstdio>
 #include <string>
 #include "base/commandlineflags.h"
-#include "glog/logging.h"
-#include "glog/raw_logging.h"
+#include <glog/logging.h>
+#include <glog/raw_logging.h>
 #include "base/googleinit.h"
 
 // glog doesn't have annotation

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -62,7 +62,7 @@
  * used by both C and C++ code, so we put all the C++ together.
  */
 
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 #ifdef _MSC_VER
 


### PR DESCRIPTION
Moved `OS_*` defines to a separate public header and added a `GLOG_` prefix.