### PR TITLE
ci: replace generated headers by templates

### DIFF
--- a/.github/workflows/linux-builds.yml
+++ b/.github/workflows/linux-builds.yml
@@ -71,6 +71,13 @@ jobs:
           '*/src/mock-log.h' \
           '/usr/*' \
           --output-file coverage.info
+
+        for file in src/glog/*.h.in; do
+          name=$(basename ${file})
+          name_we=${name%.h.in}
+          sed -i "s|build_${{matrix.build_type}}/glog/${name_we}.h\$|${file}|g" coverage.info
+        done
+
         lcov --list coverage.info
 
     - name: Upload Coverage to Coveralls


### PR DESCRIPTION
Currently, coverage analysis runs particularly on generated headers. However, since these are not readily available for Coveralls their source cannot be displayed prohibiting their online inspection.

This PR patches the coverage files by replacing the paths of generated headers by their template sources.