### PR TITLE
Restore the stream format after writing the log prefix

### DIFF
--- a/src/googletest.h
+++ b/src/googletest.h
@@ -405,9 +405,12 @@ static inline string GetCapturedTestStderr() {
   return GetCapturedTestOutput(STDERR_FILENO);
 }
 
+static const std::size_t kLoggingPrefixLength = 9;
+
 // Check if the string is [IWEF](\d{8}|YEARDATE)
 static inline bool IsLoggingPrefix(const string& s) {
-  if (s.size() != 9) return false;
+  if (s.size() != kLoggingPrefixLength)
+    return false;
   if (!strchr("IWEF", s[0])) return false;
   for (size_t i = 1; i <= 8; ++i) {
     if (!isdigit(s[i]) && s[i] != "YEARDATE"[i-1]) return false;
@@ -423,15 +426,16 @@ static inline bool IsLoggingPrefix(const string& s) {
 static inline string MungeLine(const string& line) {
   string before, logcode_date, time, thread_lineinfo;
   std::size_t begin_of_logging_prefix = 0;
-  for ( ; begin_of_logging_prefix + 9 < line.size(); ++begin_of_logging_prefix) {
-    if (IsLoggingPrefix(line.substr(begin_of_logging_prefix, 9))) {
+  for (; begin_of_logging_prefix + kLoggingPrefixLength < line.size();
+       ++begin_of_logging_prefix) {
+    if (IsLoggingPrefix(
+            line.substr(begin_of_logging_prefix, kLoggingPrefixLength))) {
       break;
     }
   }
-  if (begin_of_logging_prefix > 0) {
-    if (begin_of_logging_prefix + 9 == line.size()) {
-      return line;
-    }
+  if (begin_of_logging_prefix + kLoggingPrefixLength >= line.size()) {
+    return line;
+  } else if (begin_of_logging_prefix > 0) {
     before = line.substr(0, begin_of_logging_prefix - 1);
   }
   std::istringstream iss(line.substr(begin_of_logging_prefix));

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1588,7 +1588,6 @@ void LogMessage::Init(const char* file,
     }
   }
 
-  stream().fill('0');
   data_->preserved_errno_ = errno;
   data_->severity_ = severity;
   data_->line_ = line;
@@ -1617,7 +1616,10 @@ void LogMessage::Init(const char* file,
     #ifdef GLOG_CUSTOM_PREFIX_SUPPORT
       if (custom_prefix_callback == NULL) {
     #endif
-          stream() << LogSeverityNames[severity][0]
+          std::ios saved_fmt(NULL);
+          saved_fmt.copyfmt(stream());
+          stream() << setfill('0')
+                   << LogSeverityNames[severity][0]
                    << setw(4) << 1900+data_->tm_time_.tm_year
                    << setw(2) << 1+data_->tm_time_.tm_mon
                    << setw(2) << data_->tm_time_.tm_mday
@@ -1631,6 +1633,7 @@ void LogMessage::Init(const char* file,
                    << static_cast<unsigned int>(GetTID()) << setfill('0')
                    << ' '
                    << data_->basename_ << ':' << data_->line_ << "] ";
+          stream().copyfmt(saved_fmt);
     #ifdef GLOG_CUSTOM_PREFIX_SUPPORT
       } else {
         custom_prefix_callback(

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1613,13 +1613,13 @@ void LogMessage::Init(const char* file,
   //    (log level, GMT year, month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
+      std::ios saved_fmt(NULL);
+      saved_fmt.copyfmt(stream());
+      stream().fill('0');
     #ifdef GLOG_CUSTOM_PREFIX_SUPPORT
       if (custom_prefix_callback == NULL) {
     #endif
-          std::ios saved_fmt(NULL);
-          saved_fmt.copyfmt(stream());
-          stream() << setfill('0')
-                   << LogSeverityNames[severity][0]
+          stream() << LogSeverityNames[severity][0]
                    << setw(4) << 1900+data_->tm_time_.tm_year
                    << setw(2) << 1+data_->tm_time_.tm_mon
                    << setw(2) << data_->tm_time_.tm_mday
@@ -1633,7 +1633,6 @@ void LogMessage::Init(const char* file,
                    << static_cast<unsigned int>(GetTID()) << setfill('0')
                    << ' '
                    << data_->basename_ << ':' << data_->line_ << "] ";
-          stream().copyfmt(saved_fmt);
     #ifdef GLOG_CUSTOM_PREFIX_SUPPORT
       } else {
         custom_prefix_callback(
@@ -1648,6 +1647,7 @@ void LogMessage::Init(const char* file,
         stream() << " ";
       }
     #endif
+      stream().copyfmt(saved_fmt);
   }
   data_->num_prefix_chars_ = data_->stream_.pcount();
 

--- a/src/logging_custom_prefix_unittest.cc
+++ b/src/logging_custom_prefix_unittest.cc
@@ -310,6 +310,7 @@ void TestLogging(bool check_counts) {
   int j = 1000;
   LOG(ERROR) << string("foo") << ' '<< j << ' ' << setw(10) << j << " "
              << setw(1) << hex << j;
+  LOG(INFO) << "foo " << std::setw(10) << 1.0;
 
   {
     google::LogMessage outer(__FILE__, __LINE__, GLOG_ERROR);
@@ -321,7 +322,7 @@ void TestLogging(bool check_counts) {
   LogMessage("foo", LogMessage::kNoLogPrefix, GLOG_INFO).stream() << "no prefix";
 
   if (check_counts) {
-    CHECK_EQ(base_num_infos   + 14, LogMessage::num_messages(GLOG_INFO));
+    CHECK_EQ(base_num_infos   + 15, LogMessage::num_messages(GLOG_INFO));
     CHECK_EQ(base_num_warning + 3,  LogMessage::num_messages(GLOG_WARNING));
     CHECK_EQ(base_num_errors  + 17, LogMessage::num_messages(GLOG_ERROR));
   }

--- a/src/logging_custom_prefix_unittest.err
+++ b/src/logging_custom_prefix_unittest.err
@@ -73,7 +73,8 @@ IYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] Log if every 1
 WYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] log_if this
 IYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] array
 IYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] const array
-EYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] foo 1000 0000001000 3e8
+EYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] foo 1000       1000 3e8
+IYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] foo          1
 EYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] inner
 EYEARDATE TIME__ THREADID logging_custom_prefix_unittest.cc:LINE] outer
 no prefix

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -287,6 +287,7 @@ void TestLogging(bool check_counts) {
   int j = 1000;
   LOG(ERROR) << string("foo") << ' '<< j << ' ' << setw(10) << j << " "
              << setw(1) << hex << j;
+  LOG(INFO) << "foo " << std::setw(10) << 1.0;
 
   {
     google::LogMessage outer(__FILE__, __LINE__, GLOG_ERROR);
@@ -294,8 +295,6 @@ void TestLogging(bool check_counts) {
 
     LOG(ERROR) << "inner";
   }
-
-  LOG(INFO) << "foo " << std::setw(10) << 1.0;
 
   LogMessage("foo", LogMessage::kNoLogPrefix, GLOG_INFO).stream() << "no prefix";
 

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -295,10 +295,12 @@ void TestLogging(bool check_counts) {
     LOG(ERROR) << "inner";
   }
 
+  LOG(INFO) << "foo " << std::setw(10) << 1.0;
+
   LogMessage("foo", LogMessage::kNoLogPrefix, GLOG_INFO).stream() << "no prefix";
 
   if (check_counts) {
-    CHECK_EQ(base_num_infos   + 14, LogMessage::num_messages(GLOG_INFO));
+    CHECK_EQ(base_num_infos   + 15, LogMessage::num_messages(GLOG_INFO));
     CHECK_EQ(base_num_warning + 3,  LogMessage::num_messages(GLOG_WARNING));
     CHECK_EQ(base_num_errors  + 17, LogMessage::num_messages(GLOG_ERROR));
   }

--- a/src/logging_unittest.err
+++ b/src/logging_unittest.err
@@ -73,7 +73,8 @@ IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Log if every 1, iteration 10
 WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if this
 IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] array
 IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] const array
-EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] foo 1000 0000001000 3e8
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] foo 1000       1000 3e8
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] foo          1
 EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] inner
 EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] outer
 no prefix


### PR DESCRIPTION
Resolves #695:
> when i use `glog` with `Eigen3` matrix, i found that every value in `Eigen3` matrix is pad with '0'.

We had the same issue in the past, and I applied this patch in a fork in early 2020 already.

I do not remember why exactly I had to update `MungeLine()` in `src/googletest.h`. The new implementation tries to find the prefix at any position of the `line`, not only at the beginning of a word, and preserves whitespace. It may have been because of the log lines with multiple spaces for formatted number output in `logging_unittest.err`, which were munged into one by the previous implementation and hence the comparison failed.