### PR TITLE
cmake: Fix incorrect relative-path concatenation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Guillaume Dumont <dumont.guillaume@gmail.com>
 Marco Wang <m.aesophor@gmail.com>
 Michael Tanner <michael@tannertaxpro.com>
 MiniLight <MiniLightAR@Gmail.com>
+Niklas Hambuechen <mail@nh2.me>
 romange <romange@users.noreply.github.com>
 Roman Perepelitsa <roman.perepelitsa@gmail.com>
 Sergiu Deitsch <sergiu.deitsch@gmail.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -868,7 +868,7 @@ configure_file (\"${CMAKE_CURRENT_SOURCE_DIR}/glog-modules.cmake.in\"
 file (INSTALL
   \"${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/glog-modules.cmake\"
   DESTINATION
-  \"\${CMAKE_INSTALL_PREFIX}/${_glog_CMake_INSTALLDIR}\")
+  \"${_glog_CMake_INSTALLDIR}\")
 "
   COMPONENT Development
 )

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -38,6 +38,7 @@ Marco Wang <m.aesophor@gmail.com>
 Michael Darr <mdarr@matician.com>
 Michael Tanner <michael@tannertaxpro.com>
 MiniLight <MiniLightAR@Gmail.com>
+Niklas Hambuechen <mail@nh2.me>
 Peter Collingbourne <pcc@google.com>
 Rodrigo Queiro <rodrigoq@google.com>
 romange <romange@users.noreply.github.com>


### PR DESCRIPTION
Fixes incorrect install location of `glog-modules.cmake` found in https://github.com/NixOS/nixpkgs/pull/144561#issuecomment-960296043

Please see the commit message for details.

---

CLA is signed.