### PR TITLE
ci: use codecov token

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -138,5 +138,6 @@ jobs:
         if: matrix.build_type == 'Debug'
         uses: codecov/codecov-action@v2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,5 +83,6 @@ jobs:
         if: matrix.build_type == 'Debug'
         uses: codecov/codecov-action@v2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -158,5 +158,6 @@ jobs:
         if: matrix.build_type == 'Debug'
         uses: codecov/codecov-action@v2
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
@drigz It looks like we do need to set the upload token (`CODECOV_TOKEN`) because coverage uploads[ sometimes fail](https://github.com/google/glog/runs/4435733626?check_suite_focus=true#step:11:64)  despite previously successful builds:
```console
[2021-12-06T20:25:06.918Z] ['verbose'] The error stack is: Error: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 404 - Not Found - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```

The token can be added in repository `Settings -> Secrets -> Repository secrets`. The token can be obtained from [codecov](https://app.codecov.io/gh/google/glog/settings).

Codecov settings also mention that "Github Integration is installed. However, this repository is not enabled."  Thus, glog needs to be whitelisted by following the link on the page which I don't have access to.