### PR TITLE
run clang-tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,168 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Auto
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,59 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,google-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-build-namespaces.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-global-names-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             google-runtime-int.SignedTypePrefix
+    value:           int
+  - key:             google-runtime-int.TypeSuffix
+    value:           ''
+  - key:             google-runtime-int.UnsignedTypePrefix
+    value:           uint
+  - key:             google-runtime-references.WhiteListTypes
+    value:           ''
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -404,7 +404,8 @@ static void MaybeCancelLastSeparator(State *state) {
 // "mangled_cur" is anonymous namespace.
 static bool IdentifierIsAnonymousNamespace(State *state, int length) {
   static const char anon_prefix[] = "_GLOBAL__N_";
-  return (length > (int)sizeof(anon_prefix) - 1 &&  // Should be longer.
+  return (length >
+              static_cast<int>(sizeof(anon_prefix)) - 1 &&  // Should be longer.
           StrPrefix(state->mangled_cur, anon_prefix));
 }
 

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -203,7 +203,8 @@ static inline int RUN_ALL_TESTS() {
   for (it = g_testlist.begin(); it != g_testlist.end(); ++it) {
     (*it)();
   }
-  fprintf(stderr, "Passed %d tests\n\nPASS\n", (int)g_testlist.size());
+  fprintf(stderr, "Passed %d tests\n\nPASS\n",
+          static_cast<int>(g_testlist.size()));
   return 0;
 }
 
@@ -271,8 +272,8 @@ static inline void RunSpecifiedBenchmarks() {
        ++iter) {
     clock_t start = clock();
     iter->second(iter_cnt);
-    double elapsed_ns =
-        ((double)clock() - start) / CLOCKS_PER_SEC * 1000*1000*1000;
+    double elapsed_ns = (static_cast<double>(clock()) - start) /
+                        CLOCKS_PER_SEC * 1000 * 1000 * 1000;
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat="
@@ -409,8 +410,9 @@ static const std::size_t kLoggingPrefixLength = 9;
 
 // Check if the string is [IWEF](\d{8}|YEARDATE)
 static inline bool IsLoggingPrefix(const string& s) {
-  if (s.size() != kLoggingPrefixLength)
+  if (s.size() != kLoggingPrefixLength) {
     return false;
+  }
   if (!strchr("IWEF", s[0])) return false;
   for (size_t i = 1; i <= 8; ++i) {
     if (!isdigit(s[i]) && s[i] != "YEARDATE"[i-1]) return false;
@@ -589,7 +591,7 @@ class Thread {
 
  private:
   static void* InvokeThread(void* self) {
-    ((Thread*)self)->Run();
+    (static_cast<Thread*>(self))->Run();
     return NULL;
   }
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -839,8 +839,9 @@ inline void LogDestination::LogToAllLogfiles(LogSeverity severity,
   if ( FLAGS_logtostderr ) {           // global flag: never log to file
     ColoredWriteToStderr(severity, message, len);
   } else {
-    for (int i = severity; i >= 0; --i)
+    for (int i = severity; i >= 0; --i) {
       LogDestination::MaybeLogToLogfile(i, timestamp, message, len);
+    }
   }
 }
 
@@ -1254,8 +1255,9 @@ void LogFileObject::Write(bool force_flush,
       bytes_since_flush_ += message_len;
     }
   } else {
-    if ( CycleClock_Now() >= next_flush_time_ )
+    if (CycleClock_Now() >= next_flush_time_) {
       stop_writing = false;  // check to see if disk has free space.
+    }
     return;  // no need to flush
   }
 
@@ -1691,8 +1693,9 @@ ostream& LogMessage::stream() {
 // Flush buffered message, called by the destructor, or any other function
 // that needs to synchronize the log.
 void LogMessage::Flush() {
-  if (data_->has_been_flushed_ || data_->severity_ < FLAGS_minloglevel)
+  if (data_->has_been_flushed_ || data_->severity_ < FLAGS_minloglevel) {
     return;
+  }
 
   data_->num_chars_to_log_ = data_->stream_.pcount();
   data_->num_chars_to_syslog_ =
@@ -1833,8 +1836,9 @@ void LogMessage::SendToLog() EXCLUSIVE_LOCKS_REQUIRED(log_mutex) {
 
     if (!FLAGS_logtostderr) {
       for (int i = 0; i < NUM_SEVERITIES; ++i) {
-        if ( LogDestination::log_destinations_[i] )
+        if (LogDestination::log_destinations_[i]) {
           LogDestination::log_destinations_[i]->logger_->Write(true, 0, "", 0);
+        }
       }
     }
 
@@ -2191,8 +2195,9 @@ static bool SendEmailInternal(const char*dest, const char *subject,
     FILE* pipe = popen(cmd.c_str(), "w");
     if (pipe != NULL) {
       // Add the body if we have one
-      if (body)
+      if (body) {
         fwrite(body, sizeof(char), strlen(body), pipe);
+      }
       bool ok = pclose(pipe) != -1;
       if ( !ok ) {
         if ( use_logging ) {
@@ -2524,7 +2529,7 @@ void MakeCheckOpValueString(std::ostream* os, const char& v) {
   if (v >= 32 && v <= 126) {
     (*os) << "'" << v << "'";
   } else {
-    (*os) << "char value " << (short)v;
+    (*os) << "char value " << static_cast<short>(v);
   }
 }
 
@@ -2533,7 +2538,7 @@ void MakeCheckOpValueString(std::ostream* os, const signed char& v) {
   if (v >= 32 && v <= 126) {
     (*os) << "'" << v << "'";
   } else {
-    (*os) << "signed char value " << (short)v;
+    (*os) << "signed char value " << static_cast<short>(v);
   }
 }
 
@@ -2542,7 +2547,7 @@ void MakeCheckOpValueString(std::ostream* os, const unsigned char& v) {
   if (v >= 32 && v <= 126) {
     (*os) << "'" << v << "'";
   } else {
-    (*os) << "unsigned char value " << (unsigned short)v;
+    (*os) << "unsigned char value " << static_cast<unsigned short>(v);
   }
 }
 

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -1004,7 +1004,7 @@ GLOG_CONSTEXPR int64_t LOG_PERIOD_TOL_NS = 500000;    // 500us
 // called, since it is also the array size and will be indexed by the stream
 // operator.
 GLOG_CONSTEXPR size_t MAX_CALLS = 10;
-}  // namespace LogStreamTimes
+}  // namespace LogTimes
 
 #if defined(HAVE_CXX11_CHRONO) && __cplusplus >= 201103L
 struct LogTimeRecorder {

--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -207,9 +207,10 @@ void DumpSignalInfo(int signal_number, siginfo_t *siginfo) {
   // We assume pthread_t is an integral number or a pointer, rather
   // than a complex struct.  In some environments, pthread_self()
   // returns an uint64 but in some other environments pthread_self()
-  // returns a pointer.  Hence we use C-style cast here, rather than
-  // reinterpret/static_cast, to support both types of environments.
-  formatter.AppendUint64((uintptr_t)pthread_self(), 16);
+  // returns a pointer.
+  pthread_t id = pthread_self();
+  formatter.AppendUint64(
+      reinterpret_cast<uint64>(reinterpret_cast<const char*>(id)), 16);
   formatter.AppendString(") ");
   // Only linux has the PID of the signal sender in si_pid.
 #ifdef GLOG_OS_LINUX
@@ -366,8 +367,9 @@ bool IsFailureSignalHandlerInstalled() {
   memset(&sig_action, 0, sizeof(sig_action));
   sigemptyset(&sig_action.sa_mask);
   sigaction(SIGABRT, NULL, &sig_action);
-  if (sig_action.sa_sigaction == &FailureSignalHandler)
+  if (sig_action.sa_sigaction == &FailureSignalHandler) {
     return true;
+  }
 #elif defined(GLOG_OS_WINDOWS)
   return kFailureSignalHandlerInstalled;
 #endif  // HAVE_SIGACTION

--- a/src/signalhandler_unittest.cc
+++ b/src/signalhandler_unittest.cc
@@ -54,9 +54,10 @@ static void* DieInThread(void*) {
   // We assume pthread_t is an integral number or a pointer, rather
   // than a complex struct.  In some environments, pthread_self()
   // returns an uint64 but in some other environments pthread_self()
-  // returns a pointer.  Hence we use C-style cast here, rather than
-  // reinterpret/static_cast, to support both types of environments.
-  fprintf(stderr, "0x%lx is dying\n", (long)pthread_self());
+  // returns a pointer.
+  fprintf(
+      stderr, "0x%px is dying\n",
+      static_cast<const void*>(reinterpret_cast<const char*>(pthread_self())));
   // Use volatile to prevent from these to be optimized away.
   volatile int a = 0;
   volatile int b = 1 / a;

--- a/src/stacktrace_generic-inl.h
+++ b/src/stacktrace_generic-inl.h
@@ -46,12 +46,15 @@ int GetStackTrace(void** result, int max_depth, int skip_count) {
   size = backtrace(stack, kStackLength);
   skip_count++;  // we want to skip the current frame as well
   int result_count = size - skip_count;
-  if (result_count < 0)
+  if (result_count < 0) {
     result_count = 0;
-  if (result_count > max_depth)
+  }
+  if (result_count > max_depth) {
     result_count = max_depth;
-  for (int i = 0; i < result_count; i++)
+  }
+  for (int i = 0; i < result_count; i++) {
     result[i] = stack[i + skip_count];
+  }
 
   return result_count;
 }

--- a/src/stacktrace_libunwind-inl.h
+++ b/src/stacktrace_libunwind-inl.h
@@ -70,17 +70,20 @@ int GetStackTrace(void** result, int max_depth, int skip_count) {
   skip_count++;         // Do not include the "GetStackTrace" frame
 
   while (n < max_depth) {
-    int ret = unw_get_reg(&cursor, UNW_REG_IP, (unw_word_t *) &ip);
-    if (ret < 0)
+    int ret =
+        unw_get_reg(&cursor, UNW_REG_IP, reinterpret_cast<unw_word_t *>(&ip));
+    if (ret < 0) {
       break;
+    }
     if (skip_count > 0) {
       skip_count--;
     } else {
       result[n++] = ip;
     }
     ret = unw_step(&cursor);
-    if (ret <= 0)
+    if (ret <= 0) {
       break;
+    }
   }
 
   g_tl_entered = false;

--- a/src/stacktrace_powerpc-inl.h
+++ b/src/stacktrace_powerpc-inl.h
@@ -47,7 +47,7 @@ _START_GOOGLE_NAMESPACE_
 // "STRICT_UNWINDING") to reduce the chance that a bad pointer is returned.
 template<bool STRICT_UNWINDING>
 static void **NextStackFrame(void **old_sp) {
-  void **new_sp = (void **) *old_sp;
+  void **new_sp = static_cast<void **>(*old_sp);
 
   // Check that the transition from frame pointer old_sp to frame
   // pointer new_sp isn't clearly bogus

--- a/src/stacktrace_unittest.cc
+++ b/src/stacktrace_unittest.cc
@@ -134,8 +134,9 @@ static void ATTRIBUTE_NOINLINE CheckStackTraceLeaf(void) {
 #ifdef HAVE_EXECINFO_H
     char **strings = backtrace_symbols(stack, size);
     printf("Obtained %d stack frames.\n", size);
-    for (int i = 0; i < size; i++)
+    for (int i = 0; i < size; i++) {
       printf("%s %p\n", strings[i], stack[i]);
+    }
 
     union {
       void (*p1)(int);
@@ -163,32 +164,36 @@ static void ATTRIBUTE_NOINLINE CheckStackTrace4(int i) {
   ADJUST_ADDRESS_RANGE_FROM_RA(&expected_range[2]);
   INIT_ADDRESS_RANGE(CheckStackTrace4, start, end, &expected_range[1]);
   DECLARE_ADDRESS_LABEL(start);
-  for (int j = i; j >= 0; j--)
+  for (int j = i; j >= 0; j--) {
     CheckStackTraceLeaf();
+  }
   DECLARE_ADDRESS_LABEL(end);
 }
 static void ATTRIBUTE_NOINLINE CheckStackTrace3(int i) {
   ADJUST_ADDRESS_RANGE_FROM_RA(&expected_range[3]);
   INIT_ADDRESS_RANGE(CheckStackTrace3, start, end, &expected_range[2]);
   DECLARE_ADDRESS_LABEL(start);
-  for (int j = i; j >= 0; j--)
+  for (int j = i; j >= 0; j--) {
     CheckStackTrace4(j);
+  }
   DECLARE_ADDRESS_LABEL(end);
 }
 static void ATTRIBUTE_NOINLINE CheckStackTrace2(int i) {
   ADJUST_ADDRESS_RANGE_FROM_RA(&expected_range[4]);
   INIT_ADDRESS_RANGE(CheckStackTrace2, start, end, &expected_range[3]);
   DECLARE_ADDRESS_LABEL(start);
-  for (int j = i; j >= 0; j--)
+  for (int j = i; j >= 0; j--) {
     CheckStackTrace3(j);
+  }
   DECLARE_ADDRESS_LABEL(end);
 }
 static void ATTRIBUTE_NOINLINE CheckStackTrace1(int i) {
   ADJUST_ADDRESS_RANGE_FROM_RA(&expected_range[5]);
   INIT_ADDRESS_RANGE(CheckStackTrace1, start, end, &expected_range[4]);
   DECLARE_ADDRESS_LABEL(start);
-  for (int j = i; j >= 0; j--)
+  for (int j = i; j >= 0; j--) {
     CheckStackTrace2(j);
+  }
   DECLARE_ADDRESS_LABEL(end);
 }
 
@@ -204,8 +209,9 @@ static
 void ATTRIBUTE_NOINLINE CheckStackTrace(int i) {
   INIT_ADDRESS_RANGE(CheckStackTrace, start, end, &expected_range[5]);
   DECLARE_ADDRESS_LABEL(start);
-  for (int j = i; j >= 0; j--)
+  for (int j = i; j >= 0; j--) {
     CheckStackTrace1(j);
+  }
   DECLARE_ADDRESS_LABEL(end);
 }
 

--- a/src/stacktrace_x86-inl.h
+++ b/src/stacktrace_x86-inl.h
@@ -49,7 +49,7 @@ _START_GOOGLE_NAMESPACE_
 // "STRICT_UNWINDING") to reduce the chance that a bad pointer is returned.
 template<bool STRICT_UNWINDING>
 static void **NextStackFrame(void **old_sp) {
-  void **new_sp = (void **) *old_sp;
+  void **new_sp = static_cast<void **>(*old_sp);
 
   // Check that the transition from frame pointer old_sp to frame
   // pointer new_sp isn't clearly bogus
@@ -83,8 +83,9 @@ static void **NextStackFrame(void **old_sp) {
     //       is already on its last leg, so it's ok to be slow here.
     static int page_size = getpagesize();
     void *new_sp_aligned = (void *)((uintptr_t)new_sp & ~(page_size - 1));
-    if (msync(new_sp_aligned, page_size, MS_ASYNC) == -1)
+    if (msync(new_sp_aligned, page_size, MS_ASYNC) == -1) {
       return NULL;
+    }
   }
 #endif
   return new_sp;

--- a/src/stacktrace_x86_64-inl.h
+++ b/src/stacktrace_x86_64-inl.h
@@ -68,7 +68,7 @@ class StackTraceInit {
 static StackTraceInit module_initializer;  // Force initialization
 
 static _Unwind_Reason_Code GetOneFrame(struct _Unwind_Context *uc, void *opq) {
-  trace_arg_t *targ = (trace_arg_t *) opq;
+  trace_arg_t *targ = static_cast<trace_arg_t *>(opq);
 
   if (targ->skip_count > 0) {
     targ->skip_count--;
@@ -76,16 +76,18 @@ static _Unwind_Reason_Code GetOneFrame(struct _Unwind_Context *uc, void *opq) {
     targ->result[targ->count++] = (void *) _Unwind_GetIP(uc);
   }
 
-  if (targ->count == targ->max_depth)
+  if (targ->count == targ->max_depth) {
     return _URC_END_OF_STACK;
+  }
 
   return _URC_NO_REASON;
 }
 
 // If you change this function, also change GetStackFrames below.
 int GetStackTrace(void** result, int max_depth, int skip_count) {
-  if (!ready_to_run)
+  if (!ready_to_run) {
     return 0;
+  }
 
   trace_arg_t targ;
 

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -99,7 +99,7 @@ static ATTRIBUTE_NOINLINE void DemangleInplace(char *out, int out_size) {
   if (Demangle(out, demangled, sizeof(demangled))) {
     // Demangling succeeded. Copy to out if the space allows.
     size_t len = strlen(demangled);
-    if (len + 1 <= (size_t)out_size) {  // +1 for '\0'.
+    if (len + 1 <= static_cast<size_t>(out_size)) {  // +1 for '\0'.
       SAFE_ASSERT(len < sizeof(demangled));
       memmove(out, demangled, len + 1);
     }
@@ -382,7 +382,7 @@ struct FileDescriptor {
   int get() { return fd_; }
 
  private:
-  explicit FileDescriptor(const FileDescriptor&);
+  FileDescriptor(const FileDescriptor &);
   void operator=(const FileDescriptor&);
 };
 
@@ -458,7 +458,7 @@ class LineReader {
   }
 
  private:
-  explicit LineReader(const LineReader&);
+  LineReader(const LineReader &);
   void operator=(const LineReader&);
 
   char *FindLineFeed() {
@@ -674,8 +674,9 @@ OpenObjectFileContainingPcAndGetStartAddress(uint64_t pc,
 static char *itoa_r(uintptr_t i, char *buf, size_t sz, unsigned base, size_t padding) {
   // Make sure we can write at least one NUL byte.
   size_t n = 1;
-  if (n > sz)
+  if (n > sz) {
     return NULL;
+  }
 
   if (base < 2 || base > 16) {
     buf[0] = '\000';
@@ -698,8 +699,9 @@ static char *itoa_r(uintptr_t i, char *buf, size_t sz, unsigned base, size_t pad
     *ptr++ = "0123456789abcdef"[i % base];
     i /= base;
 
-    if (padding > 0)
+    if (padding > 0) {
       padding--;
+    }
   } while (i > 0 || padding > 0);
 
   // Terminate the output with a NUL character.

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -106,7 +106,8 @@ TEST(Symbolize, Symbolize) {
 
   // The name of an internal linkage symbol is not specified; allow either a
   // mangled or an unmangled name here.
-  const char *static_func_symbol = TrySymbolize((void *)(&static_func));
+  const char *static_func_symbol =
+      TrySymbolize(reinterpret_cast<void *>(&static_func));
 
 #if !defined(_MSC_VER) || !defined(NDEBUG)
   CHECK(NULL != static_func_symbol);
@@ -281,7 +282,7 @@ TEST(Symbolize, SymbolizeStackConsumption) {
   int stack_consumed;
   const char* symbol;
 
-  symbol = SymbolizeStackConsumption((void *)(&nonstatic_func),
+  symbol = SymbolizeStackConsumption(reinterpret_cast<void *>(&nonstatic_func),
                                      &stack_consumed);
   EXPECT_STREQ("nonstatic_func", symbol);
   EXPECT_GT(stack_consumed, 0);
@@ -289,7 +290,7 @@ TEST(Symbolize, SymbolizeStackConsumption) {
 
   // The name of an internal linkage symbol is not specified; allow either a
   // mangled or an unmangled name here.
-  symbol = SymbolizeStackConsumption((void *)(&static_func),
+  symbol = SymbolizeStackConsumption(reinterpret_cast<void *>(&static_func),
                                      &stack_consumed);
   CHECK(NULL != symbol);
   EXPECT_TRUE(strcmp("static_func", symbol) == 0 ||
@@ -304,7 +305,8 @@ TEST(Symbolize, SymbolizeWithDemanglingStackConsumption) {
   int stack_consumed;
   const char* symbol;
 
-  symbol = SymbolizeStackConsumption((void *)(&Foo::func), &stack_consumed);
+  symbol = SymbolizeStackConsumption(reinterpret_cast<void *>(&Foo::func),
+                                     &stack_consumed);
 
   EXPECT_STREQ("Foo::func()", symbol);
   EXPECT_GT(stack_consumed, 0);

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -147,8 +147,11 @@ static void VLOG2Initializer() {
       VModuleInfo* info = new VModuleInfo;
       info->module_pattern = pattern;
       info->vlog_level = module_level;
-      if (head)  tail->next = info;
-      else  head = info;
+      if (head) {
+        tail->next = info;
+      } else {
+        head = info;
+      }
       tail = info;
     }
     // Skip past this entry


### PR DESCRIPTION
Define `clang-tidy` and `clang-format` configs based on `google-*` checks and `Google` style.