### PR TITLE
stdcxx: eliminate excessive use of std::string::c_str()

### DIFF
--- a/src/googletest.h
+++ b/src/googletest.h
@@ -467,7 +467,7 @@ static inline void StringReplace(string* str,
                           const string& newsub) {
   size_t pos = str->find(oldsub);
   if (pos != string::npos) {
-    str->replace(pos, oldsub.size(), newsub.c_str());
+    str->replace(pos, oldsub.size(), newsub);
   }
 }
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1660,7 +1660,7 @@ void LogMessage::Init(const char* file,
     char fileline[128];
     snprintf(fileline, sizeof(fileline), "%s:%d", data_->basename_, line);
 #ifdef HAVE_STACKTRACE
-    if (!strcmp(FLAGS_log_backtrace_at.c_str(), fileline)) {
+    if (FLAGS_log_backtrace_at == fileline) {
       string stacktrace;
       DumpStackTraceToString(&stacktrace);
       stream() << " (stacktrace:\n" << stacktrace << ") ";
@@ -2288,7 +2288,7 @@ const vector<string>& GetLoggingDirectories() {
 
     if ( !FLAGS_log_dir.empty() ) {
       // A dir was specified, we should use it
-      logging_directories_list->push_back(FLAGS_log_dir.c_str());
+      logging_directories_list->push_back(FLAGS_log_dir);
     } else {
       GetTempDirectories(logging_directories_list);
 #ifdef GLOG_OS_WINDOWS


### PR DESCRIPTION
It could be more clear and slightly more efficient not to convert an
`std::string` into a C-style string whenever possible.