### PR TITLE
LogCleaner: avoid scanning logs too frequently

### DIFF
--- a/src/cleanup_with_absolute_prefix_unittest.cc
+++ b/src/cleanup_with_absolute_prefix_unittest.cc
@@ -64,6 +64,10 @@ TEST(CleanImmediatelyWithAbsolutePrefix, logging) {
     LOG(INFO) << "cleanup test";
   }
 
+  for (unsigned i = 0; i < 10; ++i) {
+    LOG(ERROR) << "cleanup test";
+  }
+
   google::DisableLogCleaner();
 }
 


### PR DESCRIPTION
This patch is for the performance issue : #753. 

Originally, "LogCleaner" scanned all the log directories every time we flush. In the common case, we flush every 30 seconds and then called "LogCleaner::Run". But if we flush every time we do "LogFileObject::Write" like the test code from @kimi20071025, we'll call "LogCleaner::Run" so many times.

In this patch, I maintain an additional timer `next_cleanup_time_ ` ( thank @aesophor  for the advice  ), and avoid scanning the logs too frequently.