### PR TITLE
On Solaris, GetHostName() returns empty string

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -238,7 +238,7 @@ static ssize_t pwrite(int fd, void* buf, size_t count, off_t offset) {
 static void GetHostName(string* hostname) {
 #if defined(HAVE_SYS_UTSNAME_H)
   struct utsname buf;
-  if (0 != uname(&buf)) {
+  if (uname(&buf) < 0) {
     // ensure null termination on failure
     *buf.nodename = '\0';
   }


### PR DESCRIPTION
### Description
Currently on SunOS, a call to `GetHostName()` will return an empty hostname. This is because the return value of `uname()` is a "non-negative value" as per the man page, but in my testing it seems to return 1. This causes the returned hostname value to be an empty string in calls to `GetHostName()` or "(unknown)" in calls to `LogDestination::hostname()`. Example log file:
```
Log file created at: 2022/01/14 15:29:08
Running on machine: (unknown)
```

### Changes
Modifying this code to check for a return value of less than zero will work on Solaris as well as Linux and AIX. I don't know how useful this would be to the general populace seeing most folks are running on Linux, but I figured it wouldn't hurt considering the triviality of the actual code change.

### Notes
[Solaris uname manpage](https://docs.oracle.com/cd/E18752_01/html/816-5167/uname-2.html#REFMAN2uname-2)
[AIX uname manpage](https://www.ibm.com/docs/en/zos/2.4.0?topic=functions-uname-display-current-operating-system-name)
[Linux manpage](https://man7.org/linux/man-pages/man2/uname.2.html)