### PR TITLE
Add the logtostdout and colorlogtostdout flag to allow logging to stdout

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -428,6 +428,12 @@ typedef void(*CustomPrefixCallback)(std::ostream& s, const LogMessageInfo& l, vo
 // Set whether appending a timestamp to the log file name
 DECLARE_bool(timestamp_in_logfile_name);
 
+// Set whether log messages go to stdout instead of logfiles
+DECLARE_bool(logtostdout);
+
+// Set color messages logged to stdout (if supported by terminal).
+DECLARE_bool(colorlogtostdout);
+
 // Set whether log messages go to stderr instead of logfiles
 DECLARE_bool(logtostderr);
 

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -350,6 +350,9 @@ static inline void CaptureTestOutput(int fd, const string & filename) {
   CHECK(s_captured_streams[fd] == NULL);
   s_captured_streams[fd] = new CapturedStream(fd, filename);
 }
+static inline void CaptureTestStdout() {
+  CaptureTestOutput(STDOUT_FILENO, FLAGS_test_tmpdir + "/captured.out");
+}
 static inline void CaptureTestStderr() {
   CaptureTestOutput(STDERR_FILENO, FLAGS_test_tmpdir + "/captured.err");
 }
@@ -504,9 +507,13 @@ static inline void WriteToFile(const string& body, const string& file) {
   fclose(fp);
 }
 
-static inline bool MungeAndDiffTestStderr(const string& golden_filename) {
-  CapturedStream* cap = s_captured_streams[STDERR_FILENO];
-  CHECK(cap) << ": did you forget CaptureTestStderr()?";
+static inline bool MungeAndDiffTest(const string& golden_filename,
+                                    CapturedStream* cap) {
+  if (cap == s_captured_streams[STDOUT_FILENO]) {
+    CHECK(cap) << ": did you forget CaptureTestStdout()?";
+  } else {
+    CHECK(cap) << ": did you forget CaptureTestStderr()?";
+  }
 
   cap->StopCapture();
 
@@ -534,6 +541,14 @@ static inline bool MungeAndDiffTestStderr(const string& golden_filename) {
   }
   LOG(INFO) << "Diff was successful";
   return true;
+}
+
+static inline bool MungeAndDiffTestStderr(const string& golden_filename) {
+  return MungeAndDiffTest(golden_filename, s_captured_streams[STDERR_FILENO]);
+}
+
+static inline bool MungeAndDiffTestStdout(const string& golden_filename) {
+  return MungeAndDiffTest(golden_filename, s_captured_streams[STDOUT_FILENO]);
 }
 
 // Save flags used from logging_unittest.cc.

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -242,6 +242,22 @@ int main(int argc, char **argv) {
 
   FLAGS_logtostderr = false;
 
+  FLAGS_logtostdout = true;
+  FLAGS_stderrthreshold = NUM_SEVERITIES;
+  CaptureTestStdout();
+  TestRawLogging();
+  TestLoggingLevels();
+  TestLogString();
+  TestLogSink();
+  TestLogToString();
+  TestLogSinkWaitTillSent();
+  TestCHECK();
+  TestDCHECK();
+  TestSTREQ();
+  EXPECT_TRUE(
+      MungeAndDiffTestStdout(FLAGS_test_srcdir + "/src/logging_unittest.out"));
+  FLAGS_logtostdout = false;
+
   TestBasename();
   TestBasenameAppendWhenNoTimestamp();
   TestTwoProcessesWrite();
@@ -1263,6 +1279,9 @@ class TestWaitingLogSink : public LogSink {
 // Check that LogSink::WaitTillSent can be used in the advertised way.
 // We also do golden-stderr comparison.
 static void TestLogSinkWaitTillSent() {
+  // Clear global_messages here to make sure that this test case can be
+  // reentered
+  global_messages.clear();
   { TestWaitingLogSink sink;
     // Sleeps give the sink threads time to do all their work,
     // so that we get a reliable log capture to compare to the golden file.

--- a/src/logging_unittest.out
+++ b/src/logging_unittest.out
@@ -1,0 +1,150 @@
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if -1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if info every 1 expr
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] log_if error every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] vlog_if 0 every 1 expr
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_STRING: reported error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected info
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected warning
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_STRING:  LOG_STRING: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: reported error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_SINK:
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_SINK_BUT_NOT_TO_LOGFILE: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected info
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected warning
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Captured by LOG_TO_STRING:  LOG_TO_STRING: collected error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported info
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported warning
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] LOG_TO_STRING: reported error
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
+EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
+WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink is sending out a message: WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Have 0 left
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 1
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: EYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 2
+IYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Sink capture: WYEARDATE TIME__ THREADID logging_unittest.cc:LINE] Message 3

--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -123,8 +123,9 @@ static char crash_buf[kLogBufSize + 1] = { 0 };  // Will end in '\0'
 GLOG_ATTRIBUTE_FORMAT(printf, 4, 5)
 void RawLog__(LogSeverity severity, const char* file, int line,
               const char* format, ...) {
-  if (!(FLAGS_logtostderr || severity >= FLAGS_stderrthreshold ||
-        FLAGS_alsologtostderr || !IsGoogleLoggingInitialized())) {
+  if (!(FLAGS_logtostdout || FLAGS_logtostderr ||
+        severity >= FLAGS_stderrthreshold || FLAGS_alsologtostderr ||
+        !IsGoogleLoggingInitialized())) {
     return;  // this stderr log message is suppressed
   }
   // can't call localtime_r here: it can allocate


### PR DESCRIPTION
Currently, glog allowed to use logtostderr to send error logs to stderr,
but many log tailors would regard logs from stderr as error logs. So we
want to send non-error logs to stdout and only send error logs to stderr
according to the stderrthreshold.

Resolved #701 