### PR TITLE
cmake_package_config_generate: Fix CMake warnings with CMake 3.23

### DIFF
--- a/cmake/TestPackageConfig.cmake
+++ b/cmake/TestPackageConfig.cmake
@@ -23,7 +23,7 @@ execute_process (
   # modified again (e.g., for MinGW AppVeyor CI builds) by adding back the
   # directory containing git.exe. Incidently, the Git installation directory
   # also contains sh.exe which causes MinGW Makefile generation to fail.
-  COMMAND ${CMAKE_COMMAND} env PATH=${PATH}
+  COMMAND ${CMAKE_COMMAND} -E env PATH=${PATH}
   ${CMAKE_COMMAND} -C ${INITIAL_CACHE}
     -G ${GENERATOR}
     ${_ADDITIONAL_ARGS}


### PR DESCRIPTION
Correct syntax to run CMake built-in command-line tools is `cmake -E`:
https://cmake.org/cmake/help/v3.23/manual/cmake.1.html#run-a-command-line-tool

This test was mistakenly using `cmake env ... cmake ...`, where `env` and second `cmake` were interpreted as paths (of source directory or build directory), resulting in "Ignoring extra path from command line" CMake warnings with CMake 3.23.

Warnings in verbose test log (`${glob_build_dir}/Testing/Temporary/LastTest.log`) may look in this way:
```
CMake Warning:
  Ignoring extra path from command line:

   "${glog_build_dir}/test_package_config/working_config/env"


CMake Warning:
  Ignoring extra path from command line:

   "/usr/bin/cmake"


```
This type of cmake warning was originally introduced by [cmake commit eacf1f879b0933509efbd4fb4d6d72ce99412aa7](https://gitlab.kitware.com/cmake/cmake/-/commit/eacf1f879b0933509efbd4fb4d6d72ce99412aa7).