### PR TITLE
Tests: Respect TEST_TMPDIR, TMPDIR, TMP environmental variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -623,7 +623,7 @@ by :cpp:`InstallFailureFunction`.
 
    void YourFailureFunction() {
      // Reports something...
-     exit(1);
+     exit(EXIT_FAILURE);
    }
 
    int main(int argc, char* argv[]) {

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1954,7 +1954,7 @@ class GLOG_EXPORT NullStreamFatal : public NullStream {
 #pragma warning(push)
 #pragma warning(disable : 4722)
 #endif // _MSC_VER
-  @ac_cv___attribute___noreturn@ ~NullStreamFatal() throw () { _exit(1); }
+  @ac_cv___attribute___noreturn@ ~NullStreamFatal() throw () { _exit(EXIT_FAILURE); }
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif // _MSC_VER

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1819,7 +1819,7 @@ GLOG_EXPORT const std::vector<std::string>& GetLoggingDirectories();
 void TestOnly_ClearLoggingDirectoriesList();
 
 // Returns a set of existing temporary directories, which will be a
-// subset of the directories returned by GetLogginDirectories().
+// subset of the directories returned by GetLoggingDirectories().
 // Thread-safe.
 GLOG_EXPORT void GetExistingTempDirectories(
     std::vector<std::string>* list);

--- a/src/glog/raw_logging.h.in
+++ b/src/glog/raw_logging.h.in
@@ -124,7 +124,7 @@
 #define RAW_LOG_FATAL(...) \
   do { \
     @ac_google_namespace@::RawLogStub__(0, __VA_ARGS__);        \
-    exit(1); \
+    exit(EXIT_FAILURE); \
   } while (0)
 #endif // STRIP_LOG <= 3
 

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -76,13 +76,16 @@ _END_GOOGLE_NAMESPACE_
 #define GLOG_EXPORT
 
 static inline string GetTempDir() {
-#ifndef GLOG_OS_WINDOWS
-  return "/tmp";
-#else
-  char tmp[MAX_PATH];
-  GetTempPathA(MAX_PATH, tmp);
-  return tmp;
-#endif
+  vector<string> temp_directories_list;
+  google::GetExistingTempDirectories(&temp_directories_list);
+
+  if (temp_directories_list.empty()) {
+    fprintf(stderr, "No temporary directory found\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // Use first directory from list of existing temporary directories.
+  return temp_directories_list.front();
 }
 
 #if defined(GLOG_OS_WINDOWS) && defined(_MSC_VER) && !defined(TEST_SRC_DIR)

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -130,7 +130,7 @@ void InitGoogleTest(int*, char**) {}
     if (abs(val1 - val2) > abs_error) {                                        \
       fprintf(stderr, "Check failed: %s within %s of %s\n", #val1, #abs_error, \
               #val2);                                                          \
-      exit(1);                                                                 \
+      exit(EXIT_FAILURE);                                                      \
     }                                                                          \
   } while (0)
 
@@ -138,7 +138,7 @@ void InitGoogleTest(int*, char**) {}
   do {                                                  \
     if (!(cond)) {                                      \
       fprintf(stderr, "Check failed: %s\n", #cond);     \
-      exit(1);                                          \
+      exit(EXIT_FAILURE);                               \
     }                                                   \
   } while (0)
 
@@ -148,7 +148,7 @@ void InitGoogleTest(int*, char**) {}
   do {                                                                  \
     if (!((val1) op (val2))) {                                          \
       fprintf(stderr, "Check failed: %s %s %s\n", #val1, #op, #val2);   \
-      exit(1);                                                          \
+      exit(EXIT_FAILURE);                                               \
     }                                                                   \
   } while (0)
 
@@ -161,7 +161,7 @@ void InitGoogleTest(int*, char**) {}
   do {                                                          \
     if (!isnan(arg)) {                                          \
       fprintf(stderr, "Check failed: isnan(%s)\n", #arg);       \
-      exit(1);                                                  \
+      exit(EXIT_FAILURE);                                       \
     }                                                           \
   } while (0)
 
@@ -169,7 +169,7 @@ void InitGoogleTest(int*, char**) {}
   do {                                                          \
     if (!isinf(arg)) {                                          \
       fprintf(stderr, "Check failed: isinf(%s)\n", #arg);       \
-      exit(1);                                                  \
+      exit(EXIT_FAILURE);                                       \
     }                                                           \
   } while (0)
 
@@ -177,7 +177,7 @@ void InitGoogleTest(int*, char**) {}
   do {                                                                  \
     if (((val1) < (val2) - 0.001 || (val1) > (val2) + 0.001)) {         \
       fprintf(stderr, "Check failed: %s == %s\n", #val1, #val2);        \
-      exit(1);                                                          \
+      exit(EXIT_FAILURE);                                               \
     }                                                                   \
   } while (0)
 
@@ -185,7 +185,7 @@ void InitGoogleTest(int*, char**) {}
   do {                                                                  \
     if (strcmp((val1), (val2)) != 0) {                                  \
       fprintf(stderr, "Check failed: streq(%s, %s)\n", #val1, #val2);   \
-      exit(1);                                                          \
+      exit(EXIT_FAILURE);                                               \
     }                                                                   \
   } while (0)
 
@@ -239,7 +239,7 @@ static inline void CalledAbort() {
     g_logging_fail_func = original_logging_fail_func;                   \
     if (!g_called_abort) {                                              \
       fprintf(stderr, "Function didn't die (%s): %s\n", msg, #fn);      \
-      exit(1);                                                          \
+      exit(EXIT_FAILURE);                                               \
     }                                                                   \
   } while (0)
 #endif

--- a/src/logging_custom_prefix_unittest.cc
+++ b/src/logging_custom_prefix_unittest.cc
@@ -783,7 +783,7 @@ static void TestTwoProcessesWrite() {
   if (pid == 0) {
     LOG(INFO) << "message to new base, child - should only appear on STDERR not on the file";
     ShutdownGoogleLogging(); //for children proc
-    exit(0);
+    exit(EXIT_SUCCESS);
   } else if (pid > 0) {
     wait(NULL);
   }

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -778,7 +778,7 @@ static void TestTwoProcessesWrite() {
   if (pid == 0) {
     LOG(INFO) << "message to new base, child - should only appear on STDERR not on the file";
     ShutdownGoogleLogging(); //for children proc
-    exit(0);
+    exit(EXIT_SUCCESS);
   } else if (pid > 0) {
     wait(NULL);
   }


### PR DESCRIPTION
Use GetExistingTempDirectories() (which uses GetTempDirectories() which respects
TEST_TMPDIR, TMPDIR, TMP environmental variables) for FLAGS_test_tmpdir variable
used in some tests.

Fixes: #793