### PR TITLE
Add clang-cl.exe to Bazel CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -51,7 +51,7 @@ tasks:
     - "--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl"
     - "--extra_execution_platforms=//:x64_windows-clang-cl"
     - "--features=layering_check"
-    - "--copt=/WX"
+    - "--copt=-Wno-macro-redefined"
     build_targets:
     - "//..."
     test_flags:
@@ -59,6 +59,6 @@ tasks:
     - "--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl"
     - "--extra_execution_platforms=//:x64_windows-clang-cl"
     - "--features=layering_check"
-    - "--copt=/WX"
+    - "--copt=-Wno-macro-redefined"
     test_targets:
     - "//..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,8 @@
 ---
-platforms:
+tasks:
   ubuntu1804:
+    name: "Ubuntu 18.04"
+    platform: ubuntu1804
     build_flags:
     - "--features=layering_check"
     - "--copt=-Werror"
@@ -12,6 +14,8 @@ platforms:
     test_targets:
     - "//..."
   macos:
+    name: "macOS: latest Xcode"
+    platform: macos
     build_flags:
     - "--features=layering_check"
     - "--copt=-Werror"
@@ -22,8 +26,9 @@ platforms:
     - "--copt=-Werror"
     test_targets:
     - "//..."
-  windows:
-    # Optional: use VS 2017 instead of 2015.
+  windows-msvc:
+    name: "Windows: MSVC 2017"
+    platform: windows
     environment:
       BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC"
     build_flags:
@@ -32,6 +37,27 @@ platforms:
     build_targets:
     - "//..."
     test_flags:
+    - "--features=layering_check"
+    - "--copt=/WX"
+    test_targets:
+    - "//..."
+  windows-clang-cl:
+    name: "Windows: Clang"
+    platform: windows
+    environment:
+      BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC"
+    build_flags:
+    - "--incompatible_enable_cc_toolchain_resolution"
+    - "--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl"
+    - "--extra_execution_platforms=//:x64_windows-clang-cl"
+    - "--features=layering_check"
+    - "--copt=/WX"
+    build_targets:
+    - "//..."
+    test_flags:
+    - "--incompatible_enable_cc_toolchain_resolution"
+    - "--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl"
+    - "--extra_execution_platforms=//:x64_windows-clang-cl"
     - "--features=layering_check"
     - "--copt=/WX"
     test_targets:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,22 @@
-licenses(['notice'])
+licenses(["notice"])
 
 exports_files(["COPYING"])
 
-load(':bazel/glog.bzl', 'glog_library')
+load(":bazel/glog.bzl", "glog_library")
 
 glog_library()
+
+# platform() to build with clang-cl on Bazel CI. This is enabled with
+# the flags in .bazelci/presubmit.yml:
+#
+#   --incompatible_enable_cc_toolchain_resolution
+#   --extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl
+#   --extra_execution_platforms=//:x64_windows-clang-cl
+platform(
+    name = "x64_windows-clang-cl",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+        "@bazel_tools//tools/cpp:clang-cl",
+    ],
+)


### PR DESCRIPTION
This should catch issues like #801. This uses the new `tasks` syntax to
define multiple Windows tasks:

https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/README.md#basic-syntax

I've removed `/WX` to allow warnings because there are quite a few, and I'm not confident enough in my C++ to dig into solving them. https://buildkite.com/bazel/google-logging/builds/2611#8de3f805-297c-484e-a63d-2092e8e49faa