### PR TITLE
Fix "'GLOG_EXPORT' macro redefined" on clang-cl

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -47,18 +47,12 @@ tasks:
     environment:
       BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC"
     build_flags:
-    - "--incompatible_enable_cc_toolchain_resolution"
-    - "--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl"
-    - "--extra_execution_platforms=//:x64_windows-clang-cl"
+    - "--compiler=clang-cl"
     - "--features=layering_check"
-    - "--copt=-Wno-macro-redefined"
     build_targets:
     - "//..."
     test_flags:
-    - "--incompatible_enable_cc_toolchain_resolution"
-    - "--extra_toolchains=@local_config_cc//:cc-toolchain-x64_windows-clang-cl"
-    - "--extra_execution_platforms=//:x64_windows-clang-cl"
+    - "--compiler=clang-cl"
     - "--features=layering_check"
-    - "--copt=-Wno-macro-redefined"
     test_targets:
     - "//..."


### PR DESCRIPTION
The previous approach used
--incompatible_enable_cc_toolchain_resolution, which is recommended by
the docs, but a Bazel developer told me it's obsolete. The new, old
approach is simpler and should stop the warning from being user-visible.