### PR TITLE
fix thread unsafety in occasional logging when using std::atomic

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1116,7 +1116,7 @@ namespace google {
 
 #if @ac_cv_cxx11_atomic@ && __cplusplus >= 201103L
 #define SOME_KIND_OF_LOG_EVERY_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0); \
+  static std::atomic<unsigned int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
   int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
   if (LOG_OCCURRENCES_MOD_N == 1 || n == 1) \
@@ -1125,7 +1125,7 @@ namespace google {
         &what_to_do).stream()
 
 #define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0); \
+  static std::atomic<unsigned int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
   int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
   if ((condition) && \
@@ -1135,7 +1135,7 @@ namespace google {
                  &what_to_do).stream()
 
 #define SOME_KIND_OF_PLOG_EVERY_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0); \
+  static std::atomic<unsigned int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
   int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
   if (LOG_OCCURRENCES_MOD_N == 1 || n == 1) \
@@ -1144,7 +1144,7 @@ namespace google {
         &what_to_do).stream()
 
 #define SOME_KIND_OF_LOG_FIRST_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0); \
+  static std::atomic<unsigned int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
   int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES; \
   if (LOG_OCCURRENCES_MOD_N <= n) \

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1116,44 +1116,38 @@ namespace google {
 
 #if @ac_cv_cxx11_atomic@ && __cplusplus >= 201103L
 #define SOME_KIND_OF_LOG_EVERY_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
+  static std::atomic<int> LOG_OCCURRENCES(1); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES_MOD_N, sizeof(int), "")); \
-  ++LOG_OCCURRENCES; \
-  if (++LOG_OCCURRENCES_MOD_N > n) LOG_OCCURRENCES_MOD_N -= n; \
-  if (LOG_OCCURRENCES_MOD_N == 1) \
+  int LOG_OCCURRENCES_MOD_N = LOG_OCCURRENCES.fetch_add(1, std::memory_order_relaxed) % n; \
+  if (LOG_OCCURRENCES_MOD_N == 1 || n == 1) \
     @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
 #define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
+  static std::atomic<int> LOG_OCCURRENCES(1); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES_MOD_N, sizeof(int), "")); \
-  ++LOG_OCCURRENCES; \
+  int LOG_OCCURRENCES_MOD_N = LOG_OCCURRENCES.fetch_add(1, std::memory_order_relaxed) % n; \
   if ((condition) && \
-      ((LOG_OCCURRENCES_MOD_N=(LOG_OCCURRENCES_MOD_N + 1) % n) == (1 % n))) \
+      (LOG_OCCURRENCES_MOD_N == 1 || n == 1)) \
     @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
                  &what_to_do).stream()
 
 #define SOME_KIND_OF_PLOG_EVERY_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
+  static std::atomic<int> LOG_OCCURRENCES(1); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES_MOD_N, sizeof(int), "")); \
-  ++LOG_OCCURRENCES; \
-  if (++LOG_OCCURRENCES_MOD_N > n) LOG_OCCURRENCES_MOD_N -= n; \
-  if (LOG_OCCURRENCES_MOD_N == 1) \
+  int LOG_OCCURRENCES_MOD_N = LOG_OCCURRENCES.fetch_add(1, std::memory_order_relaxed) % n; \
+  if (LOG_OCCURRENCES_MOD_N == 1 || n == 1) \
     @ac_google_namespace@::ErrnoLogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
 #define SOME_KIND_OF_LOG_FIRST_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0); \
+  static std::atomic<int> LOG_OCCURRENCES(1); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  if (LOG_OCCURRENCES <= n) \
-    ++LOG_OCCURRENCES; \
-  if (LOG_OCCURRENCES <= n) \
+  int LOG_OCCURRENCES_MOD_N = LOG_OCCURRENCES.fetch_add(1, std::memory_order_relaxed); \
+  if (LOG_OCCURRENCES_MOD_N <= n) \
     @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1118,7 +1118,7 @@ namespace google {
 #define SOME_KIND_OF_LOG_EVERY_N(severity, n, what_to_do) \
   static std::atomic<unsigned int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
+  int LOG_OCCURRENCES_MOD_N = static_cast<int>(++LOG_OCCURRENCES % n); \
   if (LOG_OCCURRENCES_MOD_N == 1 || n == 1) \
     @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
@@ -1127,7 +1127,7 @@ namespace google {
 #define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, what_to_do) \
   static std::atomic<unsigned int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
+  int LOG_OCCURRENCES_MOD_N = static_cast<int>(++LOG_OCCURRENCES % n); \
   if ((condition) && \
       (LOG_OCCURRENCES_MOD_N == 1 || n == 1)) \
     @ac_google_namespace@::LogMessage( \
@@ -1137,7 +1137,7 @@ namespace google {
 #define SOME_KIND_OF_PLOG_EVERY_N(severity, n, what_to_do) \
   static std::atomic<unsigned int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
+  int LOG_OCCURRENCES_MOD_N = static_cast<int>(++LOG_OCCURRENCES % n); \
   if (LOG_OCCURRENCES_MOD_N == 1 || n == 1) \
     @ac_google_namespace@::ErrnoLogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
@@ -1146,7 +1146,7 @@ namespace google {
 #define SOME_KIND_OF_LOG_FIRST_N(severity, n, what_to_do) \
   static std::atomic<unsigned int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES; \
+  int LOG_OCCURRENCES_MOD_N = static_cast<int>(++LOG_OCCURRENCES); \
   if (LOG_OCCURRENCES_MOD_N <= n) \
     @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1116,18 +1116,18 @@ namespace google {
 
 #if @ac_cv_cxx11_atomic@ && __cplusplus >= 201103L
 #define SOME_KIND_OF_LOG_EVERY_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(1); \
+  static std::atomic<int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  int LOG_OCCURRENCES_MOD_N = LOG_OCCURRENCES.fetch_add(1, std::memory_order_relaxed) % n; \
+  int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
   if (LOG_OCCURRENCES_MOD_N == 1 || n == 1) \
     @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
 #define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(1); \
+  static std::atomic<int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  int LOG_OCCURRENCES_MOD_N = LOG_OCCURRENCES.fetch_add(1, std::memory_order_relaxed) % n; \
+  int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
   if ((condition) && \
       (LOG_OCCURRENCES_MOD_N == 1 || n == 1)) \
     @ac_google_namespace@::LogMessage( \
@@ -1135,18 +1135,18 @@ namespace google {
                  &what_to_do).stream()
 
 #define SOME_KIND_OF_PLOG_EVERY_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(1); \
+  static std::atomic<int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  int LOG_OCCURRENCES_MOD_N = LOG_OCCURRENCES.fetch_add(1, std::memory_order_relaxed) % n; \
+  int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES % n; \
   if (LOG_OCCURRENCES_MOD_N == 1 || n == 1) \
     @ac_google_namespace@::ErrnoLogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
 #define SOME_KIND_OF_LOG_FIRST_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(1); \
+  static std::atomic<int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
-  int LOG_OCCURRENCES_MOD_N = LOG_OCCURRENCES.fetch_add(1, std::memory_order_relaxed); \
+  int LOG_OCCURRENCES_MOD_N = ++LOG_OCCURRENCES; \
   if (LOG_OCCURRENCES_MOD_N <= n) \
     @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \


### PR DESCRIPTION
This PR is to address https://github.com/google/glog/issues/804

Note:
1. Declare `LOG_OCCURRENCES_MOD_N` as a local, non-atomic variable and use `fetch_add % n` to get the exact modulo remainder.
2. Initialize `SOME_KIND_OF_LOG_EVERY_N` from `0` to `1` since `fetch_add` will get the previous value.
3. Add an extra condition when `n == 1`.
4. Introduce a new variable `LOG_OCCURRENCES_MOD_N` in the macro `SOME_KIND_OF_LOG_FIRST_N`. Although the name seems unrelated, I prefer not to introduce another macro to name it.
5. Remove the usage `AnnotateBenignRaceSized` for variables unlikely to be under a multi-thread situation.

I only fix the atomic version and I have no idea if other versions have a similar problem. 
Would you mind taking a look? @sergiud  @drigz  Thanks.

Aside question:
I doubt if `AnnotateBenignRaceSized` will take effect on `std::atomic` since no data race will happen.