### PR TITLE
Strip only the first leading @ in repo name

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -33,7 +33,7 @@ def dict_union(x, y):
 
 def glog_library(namespace = "google", with_gflags = 1, **kwargs):
     if native.repository_name() != "@":
-        repo_name = native.repository_name().lstrip("@")
+        repo_name = native.repository_name()[1:] # Strip the first leading @
         gendir = "$(GENDIR)/external/" + repo_name
         src_windows = "external/%s/src/windows" % repo_name
     else:


### PR DESCRIPTION
This change is needed for glog to work with future version of Bazel when
canonical label literals is used in Bzlmod.

Context: https://docs.google.com/document/d/1N81qfCa8oskCk5LqTW-LNthy6EBrDot7bdUsjz6JFC4/edit#heading=h.5mcn15i0e1ch