### PR TITLE
CMakeLists.txt: fix build without threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,20 +192,22 @@ int main(void)
 }
 " HAVE___SYNC_VAL_COMPARE_AND_SWAP)
 
-cmake_push_check_state (RESET)
-set (CMAKE_REQUIRED_LIBRARIES Threads::Threads)
-check_cxx_source_compiles ("
-#define _XOPEN_SOURCE 500
-#include <pthread.h>
-int main(void)
-{
-  pthread_rwlock_t l;
-  pthread_rwlock_init(&l, NULL);
-  pthread_rwlock_rdlock(&l);
-  return 0;
-}
-" HAVE_RWLOCK)
-cmake_pop_check_state ()
+if (WITH_THREADS)
+  cmake_push_check_state (RESET)
+  set (CMAKE_REQUIRED_LIBRARIES Threads::Threads)
+  check_cxx_source_compiles ("
+  #define _XOPEN_SOURCE 500
+  #include <pthread.h>
+  int main(void)
+  {
+    pthread_rwlock_t l;
+    pthread_rwlock_init(&l, NULL);
+    pthread_rwlock_rdlock(&l);
+    return 0;
+  }
+  " HAVE_RWLOCK)
+  cmake_pop_check_state ()
+endif (WITH_THREADS)
 
 check_cxx_source_compiles ("
 __declspec(selectany) int a;


### PR DESCRIPTION
Fix the following build failure without threads raised since version 0.6.0 and https://github.com/google/glog/commit/4a4331f2f2de4c35ce72badf0bdc604c04eebb26:

```
CMake Error at /home/giuliobenetti/autobuild/run/instance-1/output-1/build/glog-0.6.0/CMakeFiles/CMakeTmp/CMakeLists.txt:18 (add_executable):
  Target "cmTC_ed950" links to target "Threads::Threads" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
```

Fixes:
 - http://autobuild.buildroot.org/results/bf0846a51da69169286c7af38089d204d3d242d1

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>