### PR TITLE
windows: call to FormatMessage() should _IGNORE_INSERTS

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -596,7 +596,8 @@ DECLARE_bool(log_utc_time);
     LPSTR message = NULL; \
     LPSTR msg = reinterpret_cast<LPSTR>(&message); \
     DWORD message_length = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | \
-                         FORMAT_MESSAGE_FROM_SYSTEM, \
+                         FORMAT_MESSAGE_FROM_SYSTEM | \
+                         FORMAT_MESSAGE_IGNORE_INSERTS, \
                          0, result, 0, msg, 100, NULL); \
     if (message_length > 0) { \
       @ac_google_namespace@::LogMessage(__FILE__, __LINE__, @ac_google_namespace@::GLOG_ERROR, 0, \


### PR DESCRIPTION
Calling FormatMessage without a FORMAT_MESSAGE_IGNORE_INSERTS flag could cause trouble, as explained in an article by Raymond Chen:

* The importance of the FORMAT_MESSAGE_IGNORE_INSERTS flag
  https://devblogs.microsoft.com/oldnewthing/20071128-00/?p=24353