### PR TITLE
log_file_header: add option to disable log file headers.

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -455,6 +455,9 @@ DECLARE_bool(colorlogtostderr);
 // stderr in addition to log files.
 DECLARE_int32(stderrthreshold);
 
+// Set whether the log file header should be written upon creating a file.
+DECLARE_bool(log_file_header);
+
 // Set whether the log prefix should be prepended to each line of output.
 DECLARE_bool(log_prefix);
 


### PR DESCRIPTION
Log lines can be customized for parsing by an external tool.

To simplify such customization and parsing, there should be an option to customize the file header, or at least to disable adding it.