### PR TITLE
logsink: fix multiple issues with LogSink::ToString()

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -2115,12 +2115,14 @@ void LogSink::WaitTillSent() {
 string LogSink::ToString(LogSeverity severity, const char* file, int line,
                          const LogMessageTime& logmsgtime, const char* message,
                          size_t message_len) {
-  ostringstream stream(string(message, message_len));
+  ostringstream stream;
   stream.fill('0');
 
-  stream << LogSeverityNames[severity][0]
-         << setw(4) << 1900 + logmsgtime.year()
-         << setw(2) << 1 + logmsgtime.month()
+  stream << LogSeverityNames[severity][0];
+  if (FLAGS_log_year_in_prefix) {
+    stream << setw(4) << 1900 + logmsgtime.year();
+  }
+  stream << setw(2) << 1 + logmsgtime.month()
          << setw(2) << logmsgtime.day()
          << ' '
          << setw(2) << logmsgtime.hour() << ':'
@@ -2132,7 +2134,9 @@ string LogSink::ToString(LogSeverity severity, const char* file, int line,
          << ' '
          << file << ':' << line << "] ";
 
-  stream << string(message, message_len);
+  // A call to `write' is enclosed in parenthneses to prevent possible macro
+  // expansion.  On Windows, `write' could be a macro defined for portability.
+  (stream.write)(message, static_cast<std::streamsize>(message_len));
   return stream.str();
 }
 

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -84,7 +84,7 @@
 #define getcwd  _getcwd
 #define open    _open
 #define read    _read
-#define write   _write
+#define write(fd, p, n) _write(fd, p, n)
 #define lseek   _lseek
 #define close   _close
 #define popen   _popen


### PR DESCRIPTION
1. Initializing `std::ostringstream` with a string makes no sense, as the   string becomes an initial value of an underlying buffer; seek-to-end   is not performed, so the initial value gets completely overwritten by   subsequent writing.

2. Flag `log_year_in_prefix` should be considered, as if formatting a   regular logging message.

3. Writing a buffer to `std::ostream` is better expressed with `stream.write(s,n)`.