### PR TITLE
SetLogger should delete previously set custom logger.

### DIFF
--- a/src/logging.cc
+++ b/src/logging.cc
@@ -649,7 +649,10 @@ LogDestination::~LogDestination() {
 }
 
 void LogDestination::SetLoggerImpl(base::Logger* logger) {
-  if (logger_ == logger) return;
+  if (logger_ == logger) {
+    // Prevent releasing currently held sink on reset
+    return;
+  }
 
   if (logger_ && logger_ != &fileobject_) {
     // Delete user-specified logger set via SetLogger().

--- a/src/logging_custom_prefix_unittest.cc
+++ b/src/logging_custom_prefix_unittest.cc
@@ -842,6 +842,11 @@ static void TestExtension() {
 struct MyLogger : public base::Logger {
   string data;
 
+  explicit MyLogger(bool* set_on_destruction)
+      : set_on_destruction_(set_on_destruction) {}
+
+  ~MyLogger() { *set_on_destruction_ = true; }
+
   virtual void Write(bool /* should_flush */,
                      time_t /* timestamp */,
                      const char* message,
@@ -852,19 +857,25 @@ struct MyLogger : public base::Logger {
   virtual void Flush() { }
 
   virtual uint32 LogSize() { return data.length(); }
+
+ private:
+  bool* set_on_destruction_;
 };
 
 static void TestWrapper() {
   fprintf(stderr, "==== Test log wrapper\n");
 
-  MyLogger my_logger;
+  bool custom_logger_deleted = false;
+  MyLogger* my_logger = new MyLogger(&custom_logger_deleted);
   base::Logger* old_logger = base::GetLogger(GLOG_INFO);
-  base::SetLogger(GLOG_INFO, &my_logger);
+  base::SetLogger(GLOG_INFO, my_logger);
   LOG(INFO) << "Send to wrapped logger";
+  CHECK(strstr(my_logger->data.c_str(), "Send to wrapped logger") != NULL);
   FlushLogFiles(GLOG_INFO);
-  base::SetLogger(GLOG_INFO, old_logger);
 
-  CHECK(strstr(my_logger.data.c_str(), "Send to wrapped logger") != NULL);
+  EXPECT_FALSE(custom_logger_deleted);
+  base::SetLogger(GLOG_INFO, old_logger);
+  EXPECT_TRUE(custom_logger_deleted);
 }
 
 static void TestErrno() {


### PR DESCRIPTION
As specified in the doc comment for `SetLogger`, _"the logger becomes the property of the logging module and should not be deleted by the caller"_.

Not only should the `LogDestination` delete a custom logger in its destructor, but it should also delete a previous logger when another logger is passed to `SetLogger()`.