### PR TITLE
Disable cc toolchain resolution when using Clang on Windows

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -47,11 +47,13 @@ tasks:
     environment:
       BAZEL_VC: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\VC"
     build_flags:
+    - "--noincompatible_enable_cc_toolchain_resolution"
     - "--compiler=clang-cl"
     - "--features=layering_check"
     build_targets:
     - "//..."
     test_flags:
+    - "--noincompatible_enable_cc_toolchain_resolution"
     - "--compiler=clang-cl"
     - "--features=layering_check"
     test_targets:


### PR DESCRIPTION
Different compilers on Window are not yet supported with CC toolchain resolution. Disabling cc toolchain resolution on Windows, until Bazel supports different compilers.