### PR TITLE
Provide API for logging with per-thread counters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,13 @@ else (HAVE_CXX11_ATOMIC)
   set (ac_cv_cxx11_atomic 0)
 endif (HAVE_CXX11_ATOMIC)
 
+if (DEFINED GLOG_THREAD_LOCAL_STORAGE)
+  set (ac_cv_have_thread_local_storage 1)
+  set (ac_cv_thread_local_specifier ${GLOG_THREAD_LOCAL_STORAGE})
+else (DEFINED GLOG_THREAD_LOCAL_STORAGE)
+  set (ac_cv_have_thread_local_storage 0)
+endif (DEFINED GLOG_THREAD_LOCAL_STORAGE)
+
 if (WITH_SYMBOLIZE)
   if (WIN32 OR CYGWIN)
     cmake_push_check_state (RESET)

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -265,6 +265,8 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         "@ac_cv_have_inttypes_h@": "0",
         "@ac_cv_have_u_int16_t@": "0",
         "@ac_cv_have_glog_export@": "0",
+        "@ac_cv_have_thread_local_storage@": "1",
+        "@ac_cv_thread_local_specifier@": "thread_local",
         "@ac_google_start_namespace@": "namespace google {",
         "@ac_google_end_namespace@": "}",
         "@ac_google_namespace@": "google",

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1080,9 +1080,9 @@ namespace google {
 #endif
 
 #if __cplusplus >= 201103L && @ac_cv_cxx11_chrono@ && @ac_cv_cxx11_atomic@ // Have <chrono> and <atomic>
-#define SOME_KIND_OF_LOG_EVERY_T(severity, seconds) \
+#define SOME_KIND_OF_LOG_EVERY_T(severity, seconds, storage_specifier) \
   GLOG_CONSTEXPR std::chrono::nanoseconds LOG_TIME_PERIOD = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(seconds)); \
-  static std::atomic<@ac_google_namespace@::int64> LOG_PREVIOUS_TIME_RAW; \
+  storage_specifier std::atomic<@ac_google_namespace@::int64> LOG_PREVIOUS_TIME_RAW; \
   GLOG_IFDEF_THREAD_SANITIZER( \
           AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_TIME_PERIOD, sizeof(@ac_google_namespace@::int64), "")); \
   GLOG_IFDEF_THREAD_SANITIZER( \
@@ -1095,9 +1095,9 @@ namespace google {
   if (LOG_TIME_DELTA > LOG_TIME_PERIOD) @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity).stream()
 #elif defined(GLOG_OS_WINDOWS)
-#define SOME_KIND_OF_LOG_EVERY_T(severity, seconds) \
+#define SOME_KIND_OF_LOG_EVERY_T(severity, seconds, storage_specifier) \
   GLOG_CONSTEXPR LONGLONG LOG_TIME_PERIOD = (seconds) * LONGLONG(1000000000); \
-  static LARGE_INTEGER LOG_PREVIOUS_TIME; \
+  storage_specifier LARGE_INTEGER LOG_PREVIOUS_TIME; \
   LONGLONG LOG_TIME_DELTA; \
   { \
     LARGE_INTEGER currTime; \
@@ -1112,9 +1112,9 @@ namespace google {
     @ac_google_namespace@::LogMessage( \
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity).stream()
 #else
-#define SOME_KIND_OF_LOG_EVERY_T(severity, seconds) \
+#define SOME_KIND_OF_LOG_EVERY_T(severity, seconds, storage_specifier) \
   GLOG_CONSTEXPR @ac_google_namespace@::int64 LOG_TIME_PERIOD(seconds * 1000000000); \
-  static @ac_google_namespace@::int64 LOG_PREVIOUS_TIME; \
+  storage_specifier @ac_google_namespace@::int64 LOG_PREVIOUS_TIME; \
   @ac_google_namespace@::int64 LOG_TIME_DELTA = 0; \
   { \
     timespec currentTime = {}; \
@@ -1127,8 +1127,8 @@ namespace google {
 #endif
 
 #if @ac_cv_cxx11_atomic@ && __cplusplus >= 201103L
-#define SOME_KIND_OF_LOG_EVERY_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
+#define SOME_KIND_OF_LOG_EVERY_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES_MOD_N, sizeof(int), "")); \
   ++LOG_OCCURRENCES; \
@@ -1138,8 +1138,8 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
-#define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
+#define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, storage_specifier, what_to_do) \
+  storage_specifier std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES_MOD_N, sizeof(int), "")); \
   ++LOG_OCCURRENCES; \
@@ -1149,8 +1149,8 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
                  &what_to_do).stream()
 
-#define SOME_KIND_OF_PLOG_EVERY_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
+#define SOME_KIND_OF_PLOG_EVERY_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier std::atomic<int> LOG_OCCURRENCES(0), LOG_OCCURRENCES_MOD_N(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES_MOD_N, sizeof(int), "")); \
   ++LOG_OCCURRENCES; \
@@ -1160,8 +1160,8 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
-#define SOME_KIND_OF_LOG_FIRST_N(severity, n, what_to_do) \
-  static std::atomic<int> LOG_OCCURRENCES(0); \
+#define SOME_KIND_OF_LOG_FIRST_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier std::atomic<int> LOG_OCCURRENCES(0); \
   GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(__FILE__, __LINE__, &LOG_OCCURRENCES, sizeof(int), "")); \
   if (LOG_OCCURRENCES <= n) \
     ++LOG_OCCURRENCES; \
@@ -1172,9 +1172,9 @@ namespace google {
 
 #elif defined(GLOG_OS_WINDOWS)
 
-#define SOME_KIND_OF_LOG_EVERY_N(severity, n, what_to_do) \
-  static volatile unsigned LOG_OCCURRENCES = 0; \
-  static volatile unsigned LOG_OCCURRENCES_MOD_N = 0; \
+#define SOME_KIND_OF_LOG_EVERY_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier volatile unsigned LOG_OCCURRENCES = 0; \
+  storage_specifier volatile unsigned LOG_OCCURRENCES_MOD_N = 0; \
   InterlockedIncrement(&LOG_OCCURRENCES); \
   if (InterlockedIncrement(&LOG_OCCURRENCES_MOD_N) > n) \
     InterlockedExchangeSubtract(&LOG_OCCURRENCES_MOD_N, n); \
@@ -1183,9 +1183,9 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
-#define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, what_to_do) \
-  static volatile unsigned LOG_OCCURRENCES = 0; \
-  static volatile unsigned LOG_OCCURRENCES_MOD_N = 0; \
+#define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, storage_specifier, what_to_do) \
+  storage_specifier volatile unsigned LOG_OCCURRENCES = 0; \
+  storage_specifier volatile unsigned LOG_OCCURRENCES_MOD_N = 0; \
   InterlockedIncrement(&LOG_OCCURRENCES); \
   if ((condition) && \
     ((InterlockedIncrement(&LOG_OCCURRENCES_MOD_N), \
@@ -1195,9 +1195,9 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
                  &what_to_do).stream()
 
-#define SOME_KIND_OF_PLOG_EVERY_N(severity, n, what_to_do) \
-  static volatile unsigned LOG_OCCURRENCES = 0; \
-  static volatile unsigned LOG_OCCURRENCES_MOD_N = 0; \
+#define SOME_KIND_OF_PLOG_EVERY_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier volatile unsigned LOG_OCCURRENCES = 0; \
+  storage_specifier volatile unsigned LOG_OCCURRENCES_MOD_N = 0; \
   InterlockedIncrement(&LOG_OCCURRENCES); \
   if (InterlockedIncrement(&LOG_OCCURRENCES_MOD_N) > n) \
     InterlockedExchangeSubtract(&LOG_OCCURRENCES_MOD_N, n); \
@@ -1206,8 +1206,8 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
-#define SOME_KIND_OF_LOG_FIRST_N(severity, n, what_to_do) \
-  static volatile unsigned LOG_OCCURRENCES = 0; \
+#define SOME_KIND_OF_LOG_FIRST_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier volatile unsigned LOG_OCCURRENCES = 0; \
   if (LOG_OCCURRENCES <= n) \
     InterlockedIncrement(&LOG_OCCURRENCES); \
   if (LOG_OCCURRENCES <= n) \
@@ -1217,8 +1217,8 @@ namespace google {
 
 #else
 
-#define SOME_KIND_OF_LOG_EVERY_N(severity, n, what_to_do) \
-  static int LOG_OCCURRENCES = 0, LOG_OCCURRENCES_MOD_N = 0; \
+#define SOME_KIND_OF_LOG_EVERY_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier int LOG_OCCURRENCES = 0, LOG_OCCURRENCES_MOD_N = 0; \
   __sync_add_and_fetch(&LOG_OCCURRENCES, 1); \
   if (__sync_add_and_fetch(&LOG_OCCURRENCES_MOD_N, 1) > n) \
     __sync_sub_and_fetch(&LOG_OCCURRENCES_MOD_N, n); \
@@ -1227,8 +1227,8 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
-#define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, what_to_do) \
-  static int LOG_OCCURRENCES = 0, LOG_OCCURRENCES_MOD_N = 0; \
+#define SOME_KIND_OF_LOG_IF_EVERY_N(severity, condition, n, storage_specifier, what_to_do) \
+  storage_specifier int LOG_OCCURRENCES = 0, LOG_OCCURRENCES_MOD_N = 0; \
   __sync_add_and_fetch(&LOG_OCCURRENCES, 1); \
   if ((condition) && \
       (__sync_add_and_fetch(&LOG_OCCURRENCES_MOD_N, 1) || true) && \
@@ -1238,8 +1238,8 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
                  &what_to_do).stream()
 
-#define SOME_KIND_OF_PLOG_EVERY_N(severity, n, what_to_do) \
-  static int LOG_OCCURRENCES = 0, LOG_OCCURRENCES_MOD_N = 0; \
+#define SOME_KIND_OF_PLOG_EVERY_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier int LOG_OCCURRENCES = 0, LOG_OCCURRENCES_MOD_N = 0; \
   __sync_add_and_fetch(&LOG_OCCURRENCES, 1); \
   if (__sync_add_and_fetch(&LOG_OCCURRENCES_MOD_N, 1) > n) \
     __sync_sub_and_fetch(&LOG_OCCURRENCES_MOD_N, n); \
@@ -1248,8 +1248,8 @@ namespace google {
         __FILE__, __LINE__, @ac_google_namespace@::GLOG_ ## severity, LOG_OCCURRENCES, \
         &what_to_do).stream()
 
-#define SOME_KIND_OF_LOG_FIRST_N(severity, n, what_to_do) \
-  static int LOG_OCCURRENCES = 0; \
+#define SOME_KIND_OF_LOG_FIRST_N(severity, n, storage_specifier, what_to_do) \
+  storage_specifier int LOG_OCCURRENCES = 0; \
   if (LOG_OCCURRENCES <= n) \
     __sync_add_and_fetch(&LOG_OCCURRENCES, 1); \
   if (LOG_OCCURRENCES <= n) \
@@ -1269,22 +1269,46 @@ struct CrashReason;
 GLOG_EXPORT bool IsFailureSignalHandlerInstalled();
 }  // namespace glog_internal_namespace_
 
-#define LOG_EVERY_N(severity, n)                                        \
-  SOME_KIND_OF_LOG_EVERY_N(severity, (n), @ac_google_namespace@::LogMessage::SendToLog)
+#define LOG_EVERY_N(severity, n) \
+  SOME_KIND_OF_LOG_EVERY_N(severity, (n), static, @ac_google_namespace@::LogMessage::SendToLog)
 
-#define LOG_EVERY_T(severity, T) SOME_KIND_OF_LOG_EVERY_T(severity, (T))
+#define LOG_EVERY_T(severity, T) \
+  SOME_KIND_OF_LOG_EVERY_T(severity, (T), static)
 
 #define SYSLOG_EVERY_N(severity, n) \
-  SOME_KIND_OF_LOG_EVERY_N(severity, (n), @ac_google_namespace@::LogMessage::SendToSyslogAndLog)
+  SOME_KIND_OF_LOG_EVERY_N(severity, (n), static, @ac_google_namespace@::LogMessage::SendToSyslogAndLog)
 
 #define PLOG_EVERY_N(severity, n) \
-  SOME_KIND_OF_PLOG_EVERY_N(severity, (n), @ac_google_namespace@::LogMessage::SendToLog)
+  SOME_KIND_OF_PLOG_EVERY_N(severity, (n), static, @ac_google_namespace@::LogMessage::SendToLog)
 
 #define LOG_FIRST_N(severity, n) \
-  SOME_KIND_OF_LOG_FIRST_N(severity, (n), @ac_google_namespace@::LogMessage::SendToLog)
+  SOME_KIND_OF_LOG_FIRST_N(severity, (n), static, @ac_google_namespace@::LogMessage::SendToLog)
 
 #define LOG_IF_EVERY_N(severity, condition, n) \
-  SOME_KIND_OF_LOG_IF_EVERY_N(severity, (condition), (n), @ac_google_namespace@::LogMessage::SendToLog)
+  SOME_KIND_OF_LOG_IF_EVERY_N(severity, (condition), (n), static, @ac_google_namespace@::LogMessage::SendToLog)
+
+// Versions of the logging macros that use thread-local counters.
+#if @ac_cv_have_thread_local_storage@
+
+#define LOG_EVERY_N_THREADED(severity, n) \
+  SOME_KIND_OF_LOG_EVERY_N(severity, (n), static @ac_cv_thread_local_specifier@, @ac_google_namespace@::LogMessage::SendToLog)
+
+#define LOG_EVERY_T_THREADED(severity, T) \
+  SOME_KIND_OF_LOG_EVERY_T(severity, (T), static @ac_cv_thread_local_specifier@)
+
+#define SYSLOG_EVERY_N_THREADED(severity, n) \
+  SOME_KIND_OF_LOG_EVERY_N(severity, (n), static @ac_cv_thread_local_specifier@, @ac_google_namespace@::LogMessage::SendToSyslogAndLog)
+
+#define PLOG_EVERY_N_THREADED(severity, n) \
+  SOME_KIND_OF_PLOG_EVERY_N(severity, (n), static @ac_cv_thread_local_specifier@, @ac_google_namespace@::LogMessage::SendToLog)
+
+#define LOG_FIRST_N_THREADED(severity, n) \
+  SOME_KIND_OF_LOG_FIRST_N(severity, (n), static @ac_cv_thread_local_specifier@, @ac_google_namespace@::LogMessage::SendToLog)
+
+#define LOG_IF_EVERY_N_THREADED(severity, condition, n) \
+  SOME_KIND_OF_LOG_IF_EVERY_N(severity, (condition), (n), static @ac_cv_thread_local_specifier@, @ac_google_namespace@::LogMessage::SendToLog)
+
+#endif
 
 // We want the special COUNTER value available for LOG_EVERY_X()'ed messages
 enum PRIVATE_Counter {COUNTER};


### PR DESCRIPTION
This is an RFC for a feature to allow counting loggers to use thread-local variables.

I'm writing task-based routines that spawn threads to repeatedly run a function or lambda.  Currently only the thread that "wins" the shared count to `N` gets to log which is suboptimal for this use case.

It would be nice to be able to periodically report progress from each thread with independent counters for each task's loop.

If this is something we'd want to add, I'll follow up with docs and tests.  Thanks for looking!