### PR TITLE
Set includes for glog headers in Bazel library

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -190,6 +190,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
             ":stl_logging_h",
             ":vlog_is_on_h",
         ],
+        includes = ["."],
         strip_include_prefix = "src",
         defines = final_lib_defines,
         copts = final_lib_copts,


### PR DESCRIPTION
Resolves https://github.com/google/glog/issues/837

This adds the `includes` property to the `cc_library` for `glog` so that includes are treated as system headers, suppressing issues related to lint, clang-tidy, etc. that may differ from the local project and `glog`.