### PR TITLE
add flag logcleansecs in logging.h.in

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -471,6 +471,9 @@ DECLARE_int32(logbuflevel);
 // Sets the maximum number of seconds which logs may be buffered for.
 DECLARE_int32(logbufsecs);
 
+// Sets Clean overdue logs every this many seconds
+DECLARE_int32(logcleansecs);
+
 // Log suppression level: messages logged at a lower level than this
 // are suppressed.
 DECLARE_int32(minloglevel);


### PR DESCRIPTION
After add logcleansecs into logging.h.in, we can control the logcleansecs by set FLAGS_logcleansecs
