### PR TITLE
Change SleepForMilliseconds parameter from unsigned int -> long

### DIFF
--- a/src/googletest.h
+++ b/src/googletest.h
@@ -625,7 +625,7 @@ class Thread {
 #endif
 };
 
-static inline void SleepForMilliseconds(unsigned t) {
+static inline void SleepForMilliseconds(long t) {
 #ifndef GLOG_OS_WINDOWS
 # if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 199309L
   const struct timespec req = {0, t * 1000 * 1000};


### PR DESCRIPTION
Fixes following error on 32bit platforms

src/googletest.h:631:35: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'long' in initializer list [-Wc++11-narrowing]
  const struct timespec req = {0, t * 1000 * 1000};
                                  ^~~~~~~~~~~~~~~