### PR TITLE
Fix empty stack trace when use bazel on aarch64

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -98,6 +98,11 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         "-D_GNU_SOURCE",
     ]
 
+    linux_only_copts = [
+        # For utilities.h.
+        "-DHAVE_EXECINFO_H",
+    ]
+
     darwin_only_copts = [
         # For stacktrace.
         "-DHAVE_DLADDR",
@@ -146,7 +151,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         "@bazel_tools//src/conditions:darwin": common_copts + linux_or_darwin_copts + darwin_only_copts,
         "@bazel_tools//src/conditions:freebsd": common_copts + linux_or_darwin_copts + freebsd_only_copts,
         ":wasm": common_copts + wasm_copts,
-        "//conditions:default": common_copts + linux_or_darwin_copts,
+        "//conditions:default": common_copts + linux_or_darwin_copts + linux_only_copts,
     }) + select({
         ":clang-cl": clang_cl_only_copts,
         "//conditions:default": [],


### PR DESCRIPTION
Fix issue https://github.com/google/glog/issues/904: Stack trace is empty when use bazel on aarch64

Add `-DHAVE_EXECINFO_H` to linux copts.