### PR TITLE
Fixes for OpenBSD

### DIFF
--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -60,7 +60,8 @@
 #endif
 
 #if (defined(HAVE_SYSCALL_H) || defined(HAVE_SYS_SYSCALL_H)) && \
-    (!(defined(GLOG_OS_MACOSX))) && !defined(GLOG_OS_EMSCRIPTEN)
+    (!(defined(GLOG_OS_MACOSX)) && !(defined(GLOG_OS_OPENBSD))) && \
+    !defined(GLOG_OS_EMSCRIPTEN)
 #define safe_write(fd, s, len) syscall(SYS_write, fd, s, len)
 #else
 // Not so safe, but what can you do?

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -292,6 +292,8 @@ pid_t GetTID() {
   return getpid();  // Linux:  getpid returns thread ID when gettid is absent
 #elif defined GLOG_OS_WINDOWS && !defined GLOG_OS_CYGWIN
   return static_cast<pid_t>(GetCurrentThreadId());
+#elif defined GLOG_OS_OPENBSD
+  return getthrid();
 #elif defined(HAVE_PTHREAD)
   // If none of the techniques above worked, we use pthread_self().
   return (pid_t)(uintptr_t)pthread_self();


### PR DESCRIPTION
- Usage of syscall() is not allowed
- Use getthrid() to retreive the thread ID