### PR TITLE
logging: Prevent LogStream constructor from being discarded

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,6 +29,7 @@ Andy Ying <andy@trailofbits.com>
 Bret McKee <bretmckee@google.com>
 Brian Silverman <bsilver16384@gmail.com>
 Dmitriy Arbitman <d.arbitman@gmail.com>
+Eric Kilmer <eric.d.kilmer@gmail.com>
 Fumitoshi Ukai <ukai@google.com>
 Guillaume Dumont <dumont.guillaume@gmail.com>
 Håkan L. S. Younes <hyounes@google.com>

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1344,6 +1344,15 @@ GLOG_MSVC_PUSH_DISABLE_WARNING(4275)
   class GLOG_EXPORT LogStream : public std::ostream {
 GLOG_MSVC_POP_WARNING()
   public:
+#if defined __has_attribute
+#  if __has_attribute (used)
+    // In some cases, like when compiling glog as a static library with GCC and
+    // linking against a Clang-built executable, this constructor will be
+    // removed by the linker. We use this attribute to prevent the linker from
+    // discarding it.
+    __attribute__ ((used))
+#  endif
+#endif
     LogStream(char *buf, int len, int64 ctr)
         : std::ostream(NULL),
           streambuf_(buf, len),


### PR DESCRIPTION
Fixes linker error reported in https://github.com/google/glog/issues/922

closes #922 