### PR TITLE
Switch strip_include_prefix -> includes

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -204,10 +204,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         includes = ["src"],
         defines = final_lib_defines,
         copts = final_lib_copts,
-        deps = gflags_deps + select({
-            "@bazel_tools//src/conditions:windows": [":strip_include_prefix_hack"],
-            "//conditions:default": [],
-        }),
+        deps = gflags_deps,
         **kwargs
     )
 
@@ -247,19 +244,6 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
             ],
             **kwargs
         )
-
-    # Workaround https://github.com/bazelbuild/bazel/issues/6337 by declaring
-    # the dependencies without strip_include_prefix.
-    native.cc_library(
-        name = "strip_include_prefix_hack",
-        hdrs = [
-            "src/glog/log_severity.h",
-            ":logging_h",
-            ":raw_logging_h",
-            ":stl_logging_h",
-            ":vlog_is_on_h",
-        ],
-    )
 
     expand_template(
         name = "config_h",

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -201,7 +201,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
             ":stl_logging_h",
             ":vlog_is_on_h",
         ],
-        strip_include_prefix = "src",
+        includes = ["src"],
         defines = final_lib_defines,
         copts = final_lib_copts,
         deps = gflags_deps + select({


### PR DESCRIPTION
Hey Googlers!

I was helping a Googler use a bazel tool I'd written over in https://github.com/hedronvision/bazel-compile-commands-extractor/issues/121 and noticed that the BUILD file used a `strip_include_prefix` where an `includes` will do. Swiching to `includes` would save some symlinking (see https://github.com/bazelbuild/bazel/issues/17591) and probably the windows pain you guys were experiencing there. 

So I figured toss up a quick PR to change it over, fixing his issue and trying to leave things better than I found them.  Second commit coming in a sec to propose unwinding the windows hack, now that `strip_include_prefix` is no longer in play.

Cheers,
Chris
(ex-Googler and author of some Bazel tools)