### PR TITLE
Warn about dragons in the Bazel `include` path

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -204,9 +204,11 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         # https://github.com/google/glog/issues/837: Replacing
         # `strip_include_prefix` with `includes` would avoid spamming
         # downstream projects with compiler warnings, but would also leak
-        # private headers like stacktrace.h. I suspect the only way to avoid
-        # this is to refactor the project including the CMake build, so that
-        # the private headers are in a glog_internal subdirectory.
+        # private headers like stacktrace.h, because strip_include_prefix's
+        # implementation only creates symlinks for the public hdrs. I suspect
+        # the only way to avoid this is to refactor the project including the
+        # CMake build, so that the private headers are in a glog_internal
+        # subdirectory.
         strip_include_prefix = "src",
         defines = final_lib_defines,
         copts = final_lib_copts,

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -201,6 +201,12 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
             ":stl_logging_h",
             ":vlog_is_on_h",
         ],
+        # https://github.com/google/glog/issues/837: Replacing
+        # `strip_include_prefix` with `includes` would avoid spamming
+        # downstream projects with compiler warnings, but would also leak
+        # private headers like stacktrace.h. I suspect the only way to avoid
+        # this is to refactor the project including the CMake build, so that
+        # the private headers are in a glog_internal subdirectory.
         strip_include_prefix = "src",
         defines = final_lib_defines,
         copts = final_lib_copts,


### PR DESCRIPTION
https://github.com/google/glog/issues/837 has caused a couple of disappointments for PR authors, so I'm hoping this comment can save them some time, or even help them towards finding a complete solution for the problem.