### PR TITLE
The aarch64 version test case fails

### DIFF
--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -285,7 +285,7 @@ static const char *SymbolizeStackConsumption(void *pc, int *stack_consumed) {
   return g_symbolize_result;
 }
 
-#ifdef __ppc64__
+#if  defined(__ppc64__) || defined(__aarch64__)
 // Symbolize stack consumption should be within 4kB.
 const int kStackConsumptionUpperLimit = 4096;
 #else


### PR DESCRIPTION
The aarch64 version test case fails, need to determine whether it is aarch64