### PR TITLE
SendEmail: Protect users against vulnerable logmailers

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -470,6 +470,9 @@ DECLARE_bool(stop_logging_if_full_disk);
 // Use UTC time for logging
 DECLARE_bool(log_utc_time);
 
+// Mailer used to send logging email
+DECLARE_string(logmailer);
+
 // Log messages below the GOOGLE_STRIP_LOG level will be compiled away for
 // security reasons. See LOG(severtiy) below.
 

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -560,17 +560,20 @@ struct FlagSaver {
       : v_(FLAGS_v),
         stderrthreshold_(FLAGS_stderrthreshold),
         logtostderr_(FLAGS_logtostderr),
-        alsologtostderr_(FLAGS_alsologtostderr) {}
+        alsologtostderr_(FLAGS_alsologtostderr),
+        logmailer_(FLAGS_logmailer) {}
   ~FlagSaver() {
     FLAGS_v = v_;
     FLAGS_stderrthreshold = stderrthreshold_;
     FLAGS_logtostderr = logtostderr_;
     FLAGS_alsologtostderr = alsologtostderr_;
+    FLAGS_logmailer = logmailer_;
   }
   int v_;
   int stderrthreshold_;
   bool logtostderr_;
   bool alsologtostderr_;
+  std::string logmailer_;
 };
 #endif
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -60,6 +60,7 @@
 #include <cerrno>                   // for errno
 #include <sstream>
 #include <regex>
+#include <cctype> // for std::isspace
 #ifdef GLOG_OS_WINDOWS
 #include "windows/dirent.h"
 #else

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -1489,3 +1489,31 @@ TEST(LogMsgTime, gmtoff) {
   const long utc_max_offset = 50400;
   EXPECT_TRUE( (nGmtOff >= utc_min_offset) && (nGmtOff <= utc_max_offset) );
 }
+
+TEST(EmailLogging, ValidAddress) {
+  FlagSaver saver;
+  FLAGS_logmailer = "/usr/bin/true";
+
+  EXPECT_TRUE(SendEmail("example@example.com", "Example subject", "Example body"));
+}
+
+TEST(EmailLogging, MultipleAddresses) {
+  FlagSaver saver;
+  FLAGS_logmailer = "/usr/bin/true";
+
+  EXPECT_TRUE(SendEmail("example@example.com,foo@bar.com", "Example subject", "Example body"));
+}
+
+TEST(EmailLogging, InvalidAddress) {
+  FlagSaver saver;
+  FLAGS_logmailer = "/usr/bin/true";
+
+  EXPECT_FALSE(SendEmail("hello world@foo", "Example subject", "Example body"));
+}
+
+TEST(EmailLogging, MaliciousAddress) {
+  FlagSaver saver;
+  FLAGS_logmailer = "/usr/bin/true";
+
+  EXPECT_FALSE(SendEmail("!/bin/true@example.com", "Example subject", "Example body"));
+}


### PR DESCRIPTION
glog is used on a variety of systems, and we must assume that some of them still use vulnerable mailers that have bugs or "interesting features" such as https://nvd.nist.gov/vuln/detail/CVE-2004-2771.

Let's protect users against accidental shell injection by validating the email addresses against a slightly stricter version of the regex used by HTML5 to validate addresses[1].

This should prevent triggering any unexpected behavior in these tools.

Also add some basic unit tests for the SendEmail method.

[1] https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address