### PR TITLE
Support truncate log file for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ check_function_exists (sigaltstack HAVE_SIGALTSTACK)
 check_cxx_symbol_exists (backtrace execinfo.h HAVE_EXECINFO_BACKTRACE)
 check_cxx_symbol_exists (backtrace_symbols execinfo.h
   HAVE_EXECINFO_BACKTRACE_SYMBOLS)
+check_cxx_symbol_exists (_chsize_s io.h HAVE__CHSIZE_S)
 
 # NOTE gcc does not fail if you pass a non-existent -Wno-* option as an
 # argument. However, it will happily fail if you pass the corresponding -W*

--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -114,6 +114,7 @@ def glog_library(namespace = "google", with_gflags = 1, **kwargs):
         "-DGLOG_EXPORT=__declspec(dllexport)",
         "-DGLOG_NO_ABBREVIATED_SEVERITIES",
         "-DHAVE_SNPRINTF",
+        "-DHAVE__CHSIZE_S",
         "-I" + src_windows,
     ]
 

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -130,6 +130,9 @@
 /* define if gmtime_r is available in time.h */
 #cmakedefine HAVE_GMTIME_R
 
+/* define if _chsize_s is available in io.h */
+#cmakedefine HAVE__CHSIZE_S
+
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
 #cmakedefine LT_OBJDIR


### PR DESCRIPTION
- Use `_chsize_s` (in `io.h` header) instead of `truncate` on Windows
- Reference: https://learn.microsoft.com/vi-vn/cpp/c-runtime-library/reference/chsize-s?view=msvc-150
