### PR TITLE
fix: prefer includes in same directory

### DIFF
--- a/src/base/commandlineflags.h
+++ b/src/base/commandlineflags.h
@@ -59,7 +59,7 @@
 
 #else
 
-#include <glog/logging.h>
+#include "glog/logging.h"
 
 #define DECLARE_VARIABLE(type, shorttype, name, tn) \
   namespace fL##shorttype {                         \

--- a/src/cleanup_immediately_unittest.cc
+++ b/src/cleanup_immediately_unittest.cc
@@ -27,10 +27,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <glog/logging.h>
-#include <glog/raw_logging.h>
-
 #include "base/commandlineflags.h"
+#include "glog/logging.h"
+#include "glog/raw_logging.h"
 #include "googletest.h"
 
 #ifdef HAVE_LIB_GFLAGS

--- a/src/cleanup_with_absolute_prefix_unittest.cc
+++ b/src/cleanup_with_absolute_prefix_unittest.cc
@@ -27,10 +27,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <glog/logging.h>
-#include <glog/raw_logging.h>
-
 #include "base/commandlineflags.h"
+#include "glog/logging.h"
+#include "glog/raw_logging.h"
 #include "googletest.h"
 
 #ifdef HAVE_LIB_GFLAGS

--- a/src/cleanup_with_relative_prefix_unittest.cc
+++ b/src/cleanup_with_relative_prefix_unittest.cc
@@ -27,10 +27,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <glog/logging.h>
-#include <glog/raw_logging.h>
-
 #include "base/commandlineflags.h"
+#include "glog/logging.h"
+#include "glog/raw_logging.h"
 #include "googletest.h"
 
 #ifdef HAVE_LIB_GFLAGS

--- a/src/demangle.h
+++ b/src/demangle.h
@@ -71,7 +71,7 @@
 #define BASE_DEMANGLE_H_
 
 #include "config.h"
-#include <glog/logging.h>
+#include "glog/logging.h"
 
 _START_GOOGLE_NAMESPACE_
 

--- a/src/demangle_unittest.cc
+++ b/src/demangle_unittest.cc
@@ -31,15 +31,16 @@
 //
 // Unit tests for functions in demangle.c.
 
-#include "utilities.h"
-
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <glog/logging.h>
 #include "demangle.h"
-#include "googletest.h"
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
 #include "config.h"
+#include "glog/logging.h"
+#include "googletest.h"
+#include "utilities.h"
 
 #ifdef HAVE_LIB_GFLAGS
 #include <gflags/gflags.h>

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -60,10 +60,10 @@
 #define GLOG_MSVC_POP_WARNING()
 #endif
 
-#include <glog/platform.h>
+#include "glog/platform.h"
 
 #if @ac_cv_have_glog_export@
-#include <glog/export.h>
+#include "glog/export.h"
 #endif
 
 // We care a lot about number of bits things take up.  Unfortunately,
@@ -599,8 +599,8 @@ DECLARE_string(logmailer);
 @ac_google_start_namespace@
 
 // They need the definitions of integer types.
-#include <glog/log_severity.h>
-#include <glog/vlog_is_on.h>
+#include "glog/log_severity.h"
+#include "glog/vlog_is_on.h"
 
 // Initialize google's logging library. You will see the program name
 // specified by argv0 in log outputs.

--- a/src/glog/raw_logging.h.in
+++ b/src/glog/raw_logging.h.in
@@ -39,10 +39,9 @@
 #include <ctime>
 
 @ac_google_start_namespace@
-
-#include <glog/log_severity.h>
-#include <glog/logging.h>
-#include <glog/vlog_is_on.h>
+#include "glog/log_severity.h"
+#include "glog/logging.h"
+#include "glog/vlog_is_on.h"
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push

--- a/src/glog/vlog_is_on.h.in
+++ b/src/glog/vlog_is_on.h.in
@@ -61,9 +61,9 @@
 #ifndef BASE_VLOG_IS_ON_H_
 #define BASE_VLOG_IS_ON_H_
 
-#include <glog/log_severity.h>
-
 #include <cstddef>
+
+#include "glog/log_severity.h"
 
 #if defined(__GNUC__)
 // We emit an anonymous static int* variable at every VLOG_IS_ON(n) site.

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -68,10 +68,10 @@
 #else
 #include <dirent.h> // for automatic removal of old logs
 #endif
-#include "base/commandlineflags.h"        // to get the program name
-#include <glog/logging.h>
-#include <glog/raw_logging.h>
+#include "base/commandlineflags.h"  // to get the program name
 #include "base/googleinit.h"
+#include "glog/logging.h"
+#include "glog/raw_logging.h"
 
 #ifdef HAVE_STACKTRACE
 # include "stacktrace.h"

--- a/src/logging_striptest_main.cc
+++ b/src/logging_striptest_main.cc
@@ -32,11 +32,12 @@
 // The common part of the striplog tests.
 
 #include <cstdio>
-#include <string>
 #include <iosfwd>
-#include <glog/logging.h>
+#include <string>
+
 #include "base/commandlineflags.h"
 #include "config.h"
+#include "glog/logging.h"
 
 DECLARE_bool(logtostderr);
 GLOG_DEFINE_bool(check_mode, false, "Prints 'opt' or 'dbg'");

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -49,7 +49,6 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
-#include <fstream>
 #include <memory>
 #include <queue>
 #include <sstream>
@@ -57,8 +56,8 @@
 #include <vector>
 
 #include "base/commandlineflags.h"
-#include <glog/logging.h>
-#include <glog/raw_logging.h>
+#include "glog/logging.h"
+#include "glog/raw_logging.h"
 #include "googletest.h"
 
 DECLARE_string(log_backtrace_at);  // logging.cc

--- a/src/mock-log.h
+++ b/src/mock-log.h
@@ -36,13 +36,12 @@
 #define GLOG_SRC_MOCK_LOG_H_
 
 // For GOOGLE_NAMESPACE. This must go first so we get _XOPEN_SOURCE.
-#include "utilities.h"
+#include <gmock/gmock.h>
 
 #include <string>
 
-#include <gmock/gmock.h>
-
-#include <glog/logging.h>
+#include "glog/logging.h"
+#include "utilities.h"
 
 _START_GOOGLE_NAMESPACE_
 namespace glog_testing {

--- a/src/package_config_unittest/working_config/glog_package_config.cc
+++ b/src/package_config_unittest/working_config/glog_package_config.cc
@@ -1,4 +1,4 @@
-#include <glog/logging.h>
+#include "glog/logging.h"
 
 int main(int /*argc*/, char** argv)
 {

--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -39,12 +39,14 @@
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>               // for close() and write()
 #endif
-#include <fcntl.h>                 // for open()
+#include <fcntl.h>  // for open()
+
 #include <ctime>
-#include "config.h"
-#include <glog/logging.h>          // To pick up flag settings etc.
-#include <glog/raw_logging.h>
+
 #include "base/commandlineflags.h"
+#include "config.h"
+#include "glog/logging.h"  // To pick up flag settings etc.
+#include "glog/raw_logging.h"
 
 #ifdef HAVE_STACKTRACE
 # include "stacktrace.h"

--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -31,13 +31,13 @@
 //
 // Implementation of InstallFailureSignalHandler().
 
-#include "utilities.h"
-#include "stacktrace.h"
-#include "symbolize.h"
-#include <glog/logging.h>
-
 #include <csignal>
 #include <ctime>
+
+#include "glog/logging.h"
+#include "stacktrace.h"
+#include "symbolize.h"
+#include "utilities.h"
 #ifdef HAVE_UCONTEXT_H
 # include <ucontext.h>
 #endif

--- a/src/signalhandler_unittest.cc
+++ b/src/signalhandler_unittest.cc
@@ -41,7 +41,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
-#include <glog/logging.h>
+
+#include "glog/logging.h"
 
 #ifdef HAVE_LIB_GFLAGS
 #include <gflags/gflags.h>

--- a/src/stacktrace.h
+++ b/src/stacktrace.h
@@ -34,7 +34,7 @@
 #define BASE_STACKTRACE_H_
 
 #include "config.h"
-#include <glog/logging.h>
+#include "glog/logging.h"
 
 _START_GOOGLE_NAMESPACE_
 

--- a/src/stacktrace_libunwind-inl.h
+++ b/src/stacktrace_libunwind-inl.h
@@ -37,7 +37,7 @@ extern "C" {
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 }
-#include <glog/raw_logging.h>
+#include "glog/raw_logging.h"
 #include "stacktrace.h"
 
 _START_GOOGLE_NAMESPACE_

--- a/src/stacktrace_unittest.cc
+++ b/src/stacktrace_unittest.cc
@@ -27,14 +27,15 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "utilities.h"
+#include "stacktrace.h"
 
 #include <cstdio>
 #include <cstdlib>
-#include "config.h"
+
 #include "base/commandlineflags.h"
-#include <glog/logging.h>
-#include "stacktrace.h"
+#include "config.h"
+#include "glog/logging.h"
+#include "utilities.h"
 
 #ifdef HAVE_EXECINFO_BACKTRACE_SYMBOLS
 # include <execinfo.h>

--- a/src/stl_logging_unittest.cc
+++ b/src/stl_logging_unittest.cc
@@ -27,8 +27,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <glog/logging.h>
-#include <glog/stl_logging.h>
+#include "glog/stl_logging.h"
 
 #include <functional>
 #include <iostream>
@@ -38,6 +37,7 @@
 #include <vector>
 
 #include "config.h"
+#include "glog/logging.h"
 #include "googletest.h"
 
 using namespace std;

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -119,7 +119,6 @@ _END_GOOGLE_NAMESPACE_
 #include <elf.h>
 #endif
 #include <fcntl.h>
-#include <glog/raw_logging.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -133,6 +132,7 @@ _END_GOOGLE_NAMESPACE_
 #include <cstring>
 
 #include "config.h"
+#include "glog/raw_logging.h"
 #include "symbolize.h"
 
 // Re-runs fn until it doesn't cause EINTR.

--- a/src/symbolize.h
+++ b/src/symbolize.h
@@ -54,9 +54,9 @@
 #ifndef BASE_SYMBOLIZE_H_
 #define BASE_SYMBOLIZE_H_
 
-#include "utilities.h"
 #include "config.h"
-#include <glog/logging.h>
+#include "glog/logging.h"
+#include "utilities.h"
 
 #ifdef HAVE_SYMBOLIZE
 

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -33,12 +33,11 @@
 
 #include "symbolize.h"
 
-#include <glog/logging.h>
-
 #include <csignal>
 #include <iostream>
 
 #include "config.h"
+#include "glog/logging.h"
 #include "googletest.h"
 #include "utilities.h"
 

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -52,11 +52,10 @@
 #define PRIXS __PRIS_PREFIX "X"
 #define PRIoS __PRIS_PREFIX "o"
 
-#include "base/mutex.h"  // This must go first so we get _XOPEN_SOURCE
-
 #include <string>
 
-#include <glog/logging.h>
+#include "base/mutex.h"  // This must go first so we get _XOPEN_SOURCE
+#include "glog/logging.h"
 
 #if defined(GLOG_OS_WINDOWS)
 # include "port.h"

--- a/src/utilities_unittest.cc
+++ b/src/utilities_unittest.cc
@@ -29,8 +29,9 @@
 //
 // Author: Shinichiro Hamaji
 #include "utilities.h"
+
+#include "glog/logging.h"
 #include "googletest.h"
-#include <glog/logging.h>
 
 #ifdef HAVE_LIB_GFLAGS
 #include <gflags/gflags.h>

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -32,17 +32,17 @@
 // Broken out from logging.cc by Soren Lassen
 // logging_unittest.cc covers the functionality herein
 
-#include "utilities.h"
-
-#include <cstring>
-#include <cstdlib>
 #include <cerrno>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <string>
+
 #include "base/commandlineflags.h"
-#include <glog/logging.h>
-#include <glog/raw_logging.h>
 #include "base/googleinit.h"
+#include "glog/logging.h"
+#include "glog/raw_logging.h"
+#include "utilities.h"
 
 // glog doesn't have annotation
 #define ANNOTATE_BENIGN_RACE(address, description)

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -62,7 +62,7 @@
  * used by both C and C++ code, so we put all the C++ together.
  */
 
-#include <glog/logging.h>
+#include "glog/logging.h"
 
 #ifdef _MSC_VER
 


### PR DESCRIPTION
Use quoted form instead of angle-bracket form for includes to avoid conflicts between multiple versions of the library.

Fixes #824