### PR TITLE
fix(build): raise minimum cmake version to 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.16)
+cmake_minimum_required (VERSION 3.21)
 project (glog
   VERSION 0.7.0
   DESCRIPTION "C++ implementation of the Google logging module"


### PR DESCRIPTION
Linking against target objects is otherwise not possible.

Fixes #973