### PR TITLE
cmake: replace `check_library_exists` by `check_cxx_symbol_exists`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ include (CheckCXXSourceRuns)
 include (CheckCXXSymbolExists)
 include (CheckFunctionExists)
 include (CheckIncludeFileCXX)
-include (CheckLibraryExists)
 include (CheckStructHasMember)
 include (CheckTypeSize)
 include (CMakeDependentOption)
@@ -156,7 +155,10 @@ cmake_pop_check_state ()
 # snprintf as an inline function
 check_cxx_symbol_exists (snprintf cstdio HAVE_SNPRINTF)
 
-check_library_exists (dbghelp UnDecorateSymbolName "" HAVE_DBGHELP)
+cmake_push_check_state (RESET)
+set (CMAKE_REQUIRED_LIBRARIES dbghelp)
+check_cxx_symbol_exists (UnDecorateSymbolName "windows.h;dbghelp.h" HAVE_DBGHELP)
+cmake_pop_check_state ()
 
 check_cxx_source_compiles ("
 #include <cstdlib>


### PR DESCRIPTION
As per https://gitlab.kitware.com/cmake/cmake/-/issues/18121, check_library_exists cannot not determine the availability of a symbol in a static library. Switch to check_cxx_symbol_exists to avoid incorrectly detecting the presence of dbghelp.

Fixes #982