### PR TITLE
rework public header structure

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -130,12 +130,6 @@ jobs:
           gcovr -r .. . -s --xml coverage.xml
           cd ..
 
-          for file in src/glog/*.h.in; do
-            name=$(basename ${file})
-            name_we=${name%.h.in}
-            sed -i "s|build_${{matrix.build_type}}/glog/${name_we}.h|${file}|g" build_${{matrix.build_type}}/coverage.xml
-          done
-
       - name: Upload Coverage to Codecov
         if: matrix.build_type == 'Debug'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -66,12 +66,6 @@ jobs:
           gcovr -r .. . -s --cobertura coverage.xml
           cd ..
 
-          for file in src/glog/*.h.in; do
-            name=$(basename ${file})
-            name_we=${name%.h.in}
-            sed -i "" "s|build_${{matrix.build_type}}/glog/${name_we}.h|${file}|g" build_${{matrix.build_type}}/coverage.xml
-          done
-
       - name: Upload Coverage to Codecov
         if: matrix.build_type == 'Debug'
         uses: codecov/codecov-action@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -233,12 +233,6 @@ jobs:
           gcovr -r .. . -s --cobertura coverage.xml
           cd ..
 
-          for file in src/glog/*.h.in; do
-            name=$(basename ${file})
-            name_we=${name%.h.in}
-            sed -i "s|build_${{matrix.build_type}}/glog/${name_we}.h|${file}|g" build_${{matrix.build_type}}/coverage.xml
-          done
-
       - name: Upload Coverage to Codecov
         if: matrix.build_type == 'Debug'
         uses: codecov/codecov-action@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,7 @@ endif (Unwind_FOUND)
 
 check_include_file_cxx (dlfcn.h HAVE_DLFCN_H)
 check_include_file_cxx (glob.h HAVE_GLOB_H)
-check_include_file_cxx (memory.h HAVE_MEMORY_H)
 check_include_file_cxx (pwd.h HAVE_PWD_H)
-check_include_file_cxx (strings.h HAVE_STRINGS_H)
-check_include_file_cxx (sys/stat.h HAVE_SYS_STAT_H)
 check_include_file_cxx (sys/syscall.h HAVE_SYS_SYSCALL_H)
 check_include_file_cxx (sys/time.h HAVE_SYS_TIME_H)
 check_include_file_cxx (sys/types.h HAVE_SYS_TYPES_H)
@@ -189,28 +186,6 @@ cmake_push_check_state (RESET)
 set (CMAKE_REQUIRED_LIBRARIES dbghelp)
 check_cxx_symbol_exists (UnDecorateSymbolName "windows.h;dbghelp.h" HAVE_DBGHELP)
 cmake_pop_check_state ()
-
-check_cxx_source_compiles ("
-#include <cstdlib>
-static void foo(void) __attribute__ ((unused));
-int main(void) { return 0; }
-" HAVE___ATTRIBUTE__)
-
-check_cxx_source_compiles ("
-#include <cstdlib>
-static void foo(void) __attribute__ ((visibility(\"default\")));
-int main(void) { return 0; }
-" HAVE___ATTRIBUTE__VISIBILITY_DEFAULT)
-
-check_cxx_source_compiles ("
-#include <cstdlib>
-static void foo(void) __attribute__ ((visibility(\"hidden\")));
-int main(void) { return 0; }
-" HAVE___ATTRIBUTE__VISIBILITY_HIDDEN)
-
-check_cxx_source_compiles ("
-int main(void) { if (__builtin_expect(0, 0)) return 1; return 0; }
-" HAVE___BUILTIN_EXPECT)
 
 check_cxx_source_compiles ("
 int main(void)
@@ -284,58 +259,6 @@ if (HAVE_UCONTEXT_H AND NOT DEFINED PC_FROM_UCONTEXT)
 
   cmake_pop_check_state ()
 endif (HAVE_UCONTEXT_H AND NOT DEFINED PC_FROM_UCONTEXT)
-
-set (GOOGLE_NAMESPACE google)
-set (_START_GOOGLE_NAMESPACE_ "namespace ${GOOGLE_NAMESPACE} {")
-set (_END_GOOGLE_NAMESPACE_ "}")
-set (ac_cv_have_glog_export 1)
-
-if (HAVE_LIB_GFLAGS)
-  set (ac_cv_have_libgflags 1)
-else (HAVE_LIB_GFLAGS)
-  set (ac_cv_have_libgflags 0)
-endif (HAVE_LIB_GFLAGS)
-
-if (HAVE_SYS_TYPES_H)
-  set (ac_cv_have_systypes_h 1)
-else (HAVE_SYS_TYPES_H)
-  set (ac_cv_have_systypes_h 0)
-endif (HAVE_SYS_TYPES_H)
-
-if (HAVE_SSIZE_T)
-  set (ac_cv_have_ssize_t 1)
-else (HAVE_SSIZE_T)
-  set (ac_cv_have_ssize_t 0)
-endif (HAVE_SSIZE_T)
-
-if (HAVE_MODE_T)
-  set (ac_cv_have_mode_t 1)
-else (HAVE_MODE_T)
-  set (ac_cv_have_mode_t 0)
-endif (HAVE_MODE_T)
-
-if (HAVE_UNISTD_H)
-  set (ac_cv_have_unistd_h 1)
-else (HAVE_UNISTD_H)
-  set (ac_cv_have_unistd_h 0)
-endif (HAVE_UNISTD_H)
-
-set (ac_google_namespace ${GOOGLE_NAMESPACE})
-set (ac_google_end_namespace ${_END_GOOGLE_NAMESPACE_})
-set (ac_google_start_namespace ${_START_GOOGLE_NAMESPACE_})
-
-if (HAVE___ATTRIBUTE__)
-  set (ac_cv___attribute___noinline "__attribute__((noinline))")
-  set (ac_cv___attribute___printf_4_5 "__attribute__((__format__(__printf__, 4, 5)))")
-elseif (HAVE___DECLSPEC)
-  #set (ac_cv___attribute___noinline "__declspec(noinline)")
-endif (HAVE___ATTRIBUTE__)
-
-if (HAVE___BUILTIN_EXPECT)
-  set (ac_cv_have___builtin_expect 1)
-else (HAVE___BUILTIN_EXPECT)
-  set (ac_cv_have___builtin_expect 0)
-endif (HAVE___BUILTIN_EXPECT)
 
 if (HAVE_EXECINFO_BACKTRACE AND HAVE_EXECINFO_BACKTRACE_SYMBOLS)
   set (HAVE_STACKTRACE 1)
@@ -414,10 +337,6 @@ else (CYGWIN)
 endif (CYGWIN)
 
 configure_file (src/config.h.cmake.in config.h)
-configure_file (src/glog/logging.h.in glog/logging.h @ONLY)
-configure_file (src/glog/raw_logging.h.in glog/raw_logging.h @ONLY)
-configure_file (src/glog/stl_logging.h.in glog/stl_logging.h @ONLY)
-configure_file (src/glog/vlog_is_on.h.in glog/vlog_is_on.h @ONLY)
 
 set (_glog_CMake_BINDIR ${CMAKE_INSTALL_BINDIR})
 set (_glog_CMake_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR})
@@ -459,12 +378,12 @@ endif (_glog_CMake_MODULES)
 
 set (GLOG_PUBLIC_H
   ${glog_BINARY_DIR}/glog/export.h
-  ${glog_BINARY_DIR}/glog/logging.h
-  ${glog_BINARY_DIR}/glog/raw_logging.h
-  ${glog_BINARY_DIR}/glog/stl_logging.h
-  ${glog_BINARY_DIR}/glog/vlog_is_on.h
   src/glog/log_severity.h
+  src/glog/logging.h
   src/glog/platform.h
+  src/glog/raw_logging.h
+  src/glog/stl_logging.h
+  src/glog/vlog_is_on.h
 )
 
 set (GLOG_SRCS
@@ -516,6 +435,13 @@ target_compile_features (glog PUBLIC cxx_std_14)
 add_library (glog::glog ALIAS glog)
 
 set (glog_libraries_options_for_static_linking)
+
+# CMake always uses the generated export header
+target_compile_definitions (glog PUBLIC GLOG_USE_GLOG_EXPORT)
+
+if (HAVE_LIB_GFLAGS)
+  target_compile_definitions (glog PUBLIC GLOG_USE_GFLAGS)
+endif (HAVE_LIB_GFLAGS)
 
 if (Unwind_FOUND)
   target_link_libraries (glog PRIVATE unwind::unwind)

--- a/src/base/commandlineflags.h
+++ b/src/base/commandlineflags.h
@@ -53,7 +53,7 @@
 #include <cstring>               // for memchr
 #include <string>
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 
 #include <gflags/gflags.h>
 
@@ -80,18 +80,16 @@
   DEFINE_VARIABLE(bool, B, name, value, meaning, bool)
 
 // int32 specialization
-#define DECLARE_int32(name) \
-  DECLARE_VARIABLE(GOOGLE_NAMESPACE::int32, I, name, int32)
+#define DECLARE_int32(name) DECLARE_VARIABLE(google::int32, I, name, int32)
 #define DEFINE_int32(name, value, meaning) \
-  DEFINE_VARIABLE(GOOGLE_NAMESPACE::int32, I, name, value, meaning, int32)
+  DEFINE_VARIABLE(google::int32, I, name, value, meaning, int32)
 
 // uint32 specialization
 #ifndef DECLARE_uint32
-#define DECLARE_uint32(name) \
-  DECLARE_VARIABLE(GOOGLE_NAMESPACE::uint32, U, name, uint32)
+#define DECLARE_uint32(name) DECLARE_VARIABLE(google::uint32, U, name, uint32)
 #endif // DECLARE_uint64
 #define DEFINE_uint32(name, value, meaning) \
-  DEFINE_VARIABLE(GOOGLE_NAMESPACE::uint32, U, name, value, meaning, uint32)
+  DEFINE_VARIABLE(google::uint32, U, name, value, meaning, uint32)
 
 // Special case for string, because we have to specify the namespace
 // std::string, which doesn't play nicely with our FLAG__namespace hackery.
@@ -108,7 +106,7 @@
   }                                                           \
   using fLS::FLAGS_##name
 
-#endif  // HAVE_LIB_GFLAGS
+#endif  // GLOG_USE_GFLAGS
 
 // Define GLOG_DEFINE_* using DEFINE_* . By using these macros, we
 // have GLOG_* environ variables even if we have gflags installed.

--- a/src/cleanup_immediately_unittest.cc
+++ b/src/cleanup_immediately_unittest.cc
@@ -32,7 +32,7 @@
 #include "glog/raw_logging.h"
 #include "googletest.h"
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 #include <gflags/gflags.h>
 using namespace GFLAGS_NAMESPACE;
 #endif
@@ -42,7 +42,7 @@ using namespace GFLAGS_NAMESPACE;
 
 #include "mock-log.h"
 // Introduce several symbols from gmock.
-using GOOGLE_NAMESPACE::glog_testing::ScopedMockLog;
+using google::glog_testing::ScopedMockLog;
 using testing::_;
 using testing::AllOf;
 using testing::AnyNumber;
@@ -52,7 +52,7 @@ using testing::StrictMock;
 using testing::StrNe;
 #endif
 
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 TEST(CleanImmediately, logging) {
   google::SetLogFilenameExtension(".foobar");
@@ -68,7 +68,7 @@ TEST(CleanImmediately, logging) {
 int main(int argc, char **argv) {
   FLAGS_colorlogtostderr = false;
   FLAGS_timestamp_in_logfile_name = true;
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
   ParseCommandLineFlags(&argc, &argv, true);
 #endif
   // Make sure stderr is not buffered as stderr seems to be buffered

--- a/src/cleanup_with_absolute_prefix_unittest.cc
+++ b/src/cleanup_with_absolute_prefix_unittest.cc
@@ -32,7 +32,7 @@
 #include "glog/raw_logging.h"
 #include "googletest.h"
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 #include <gflags/gflags.h>
 using namespace GFLAGS_NAMESPACE;
 #endif
@@ -42,7 +42,7 @@ using namespace GFLAGS_NAMESPACE;
 
 #include "mock-log.h"
 // Introduce several symbols from gmock.
-using GOOGLE_NAMESPACE::glog_testing::ScopedMockLog;
+using google::glog_testing::ScopedMockLog;
 using testing::_;
 using testing::AllOf;
 using testing::AnyNumber;
@@ -52,7 +52,7 @@ using testing::StrictMock;
 using testing::StrNe;
 #endif
 
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 TEST(CleanImmediatelyWithAbsolutePrefix, logging) {
   google::EnableLogCleaner(0);
@@ -73,7 +73,7 @@ TEST(CleanImmediatelyWithAbsolutePrefix, logging) {
 int main(int argc, char **argv) {
   FLAGS_colorlogtostderr = false;
   FLAGS_timestamp_in_logfile_name = true;
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
   ParseCommandLineFlags(&argc, &argv, true);
 #endif
   // Make sure stderr is not buffered as stderr seems to be buffered

--- a/src/cleanup_with_relative_prefix_unittest.cc
+++ b/src/cleanup_with_relative_prefix_unittest.cc
@@ -32,7 +32,7 @@
 #include "glog/raw_logging.h"
 #include "googletest.h"
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 #include <gflags/gflags.h>
 using namespace GFLAGS_NAMESPACE;
 #endif
@@ -42,7 +42,7 @@ using namespace GFLAGS_NAMESPACE;
 
 #include "mock-log.h"
 // Introduce several symbols from gmock.
-using GOOGLE_NAMESPACE::glog_testing::ScopedMockLog;
+using google::glog_testing::ScopedMockLog;
 using testing::_;
 using testing::AllOf;
 using testing::AnyNumber;
@@ -52,7 +52,7 @@ using testing::StrictMock;
 using testing::StrNe;
 #endif
 
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 TEST(CleanImmediatelyWithRelativePrefix, logging) {
   google::EnableLogCleaner(0);
@@ -69,7 +69,7 @@ TEST(CleanImmediatelyWithRelativePrefix, logging) {
 int main(int argc, char **argv) {
   FLAGS_colorlogtostderr = false;
   FLAGS_timestamp_in_logfile_name = true;
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
   ParseCommandLineFlags(&argc, &argv, true);
 #endif
   // Make sure stderr is not buffered as stderr seems to be buffered

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -1,9 +1,6 @@
 #ifndef GLOG_CONFIG_H
 #define GLOG_CONFIG_H
 
-/* Namespace for Google classes */
-#cmakedefine GOOGLE_NAMESPACE ${GOOGLE_NAMESPACE}
-
 /* Define if you have the `dladdr' function */
 #cmakedefine HAVE_DLADDR
 
@@ -25,9 +22,6 @@
 /* Define to 1 if you have the `pthread' library (-lpthread). */
 #cmakedefine HAVE_LIBPTHREAD
 
-/* define if you have google gflags library */
-#cmakedefine HAVE_LIB_GFLAGS
-
 /* define if you have google gmock library */
 #cmakedefine HAVE_LIB_GMOCK
 
@@ -36,9 +30,6 @@
 
 /* define if you have dbghelp library */
 #cmakedefine HAVE_DBGHELP
-
-/* Define to 1 if you have the <memory.h> header file. */
-#cmakedefine HAVE_MEMORY_H
 
 /* define to disable multithreading support. */
 #cmakedefine NO_THREADS
@@ -64,17 +55,11 @@
 /* Define if you have the `sigaltstack' function */
 #cmakedefine HAVE_SIGALTSTACK
 
-/* Define to 1 if you have the <strings.h> header file. */
-#cmakedefine HAVE_STRINGS_H
-
 /* Define to 1 if you have the <syscall.h> header file. */
 #cmakedefine HAVE_SYSCALL_H
 
 /* Define to 1 if you have the <syslog.h> header file. */
 #cmakedefine HAVE_SYSLOG_H
-
-/* Define to 1 if you have the <sys/stat.h> header file. */
-#cmakedefine HAVE_SYS_STAT_H
 
 /* Define to 1 if you have the <sys/syscall.h> header file. */
 #cmakedefine HAVE_SYS_SYSCALL_H
@@ -83,7 +68,7 @@
 #cmakedefine HAVE_SYS_TIME_H
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#cmakedefine HAVE_SYS_TYPES_H ${HAVE_SYS_TYPES_H}
+#cmakedefine HAVE_SYS_TYPES_H
 
 /* Define to 1 if you have the <sys/ucontext.h> header file. */
 #cmakedefine HAVE_SYS_UCONTEXT_H
@@ -106,12 +91,6 @@
 /* define if you have libunwind */
 #cmakedefine HAVE_LIBUNWIND
 
-/* define if your compiler has __attribute__ */
-#cmakedefine HAVE___ATTRIBUTE__
-
-/* define if your compiler has __builtin_expect */
-#cmakedefine HAVE___BUILTIN_EXPECT ${HAVE___BUILTIN_EXPECT}
-
 /* define if your compiler has __sync_val_compare_and_swap */
 #cmakedefine HAVE___SYNC_VAL_COMPARE_AND_SWAP
 
@@ -127,9 +106,11 @@
 /* define if _chsize_s is available in io.h */
 #cmakedefine HAVE__CHSIZE_S
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
-#cmakedefine LT_OBJDIR
+/* define if ssize_t is defined */
+#cmakedefine HAVE_SSIZE_T
+
+/* define if mode_t is defined */
+#cmakedefine HAVE_MODE_T
 
 /* How to access the PC from a struct ucontext */
 #cmakedefine PC_FROM_UCONTEXT ${PC_FROM_UCONTEXT}
@@ -149,24 +130,6 @@
 
 /* Define if thread-local storage is enabled. */
 #cmakedefine GLOG_THREAD_LOCAL_STORAGE
-
-#ifdef GLOG_BAZEL_BUILD
-
-/* TODO(rodrigoq): remove this workaround once bazel#3979 is resolved:
- * https://github.com/bazelbuild/bazel/issues/3979 */
-#define _START_GOOGLE_NAMESPACE_ namespace GOOGLE_NAMESPACE {
-
-#define _END_GOOGLE_NAMESPACE_ }
-
-#else
-
-/* Stops putting the code inside the Google namespace */
-#cmakedefine _END_GOOGLE_NAMESPACE_ ${_END_GOOGLE_NAMESPACE_}
-
-/* Puts following code inside the Google namespace */
-#cmakedefine _START_GOOGLE_NAMESPACE_ ${_START_GOOGLE_NAMESPACE_}
-
-#endif
 
 /* Replacement for deprecated syscall(SYS_gettid) on macOS. */
 #cmakedefine HAVE_PTHREAD_THREADID_NP ${HAVE_PTHREAD_THREADID_NP}

--- a/src/demangle.cc
+++ b/src/demangle.cc
@@ -46,7 +46,7 @@
 #include <dbghelp.h>
 #endif
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 #if !defined(GLOG_OS_WINDOWS)
 struct AbbrevPair {
@@ -1371,4 +1371,4 @@ bool Demangle(const char *mangled, char *out, size_t out_size) {
 #endif
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/demangle.h
+++ b/src/demangle.h
@@ -73,13 +73,13 @@
 #include "config.h"
 #include "glog/logging.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // Demangle "mangled".  On success, return true and write the
 // demangled symbol name to "out".  Otherwise, return false.
 // "out" is modified even if demangling is unsuccessful.
 bool GLOG_EXPORT Demangle(const char *mangled, char *out, size_t out_size);
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif  // BASE_DEMANGLE_H_

--- a/src/demangle_unittest.cc
+++ b/src/demangle_unittest.cc
@@ -42,7 +42,7 @@
 #include "googletest.h"
 #include "utilities.h"
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 #include <gflags/gflags.h>
 using namespace GFLAGS_NAMESPACE;
 #endif
@@ -51,7 +51,7 @@ GLOG_DEFINE_bool(demangle_filter, false,
                  "Run demangle_unittest in filter mode");
 
 using namespace std;
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 // A wrapper function for Demangle() to make the unit test simple.
 static const char *DemangleIt(const char * const mangled) {
@@ -148,7 +148,7 @@ TEST(Demangle, FromFile) {
 #endif
 
 int main(int argc, char **argv) {
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
   ParseCommandLineFlags(&argc, &argv, true);
 #endif
   InitGoogleTest(&argc, argv);

--- a/src/glog/raw_logging.h
+++ b/src/glog/raw_logging.h
@@ -38,7 +38,7 @@
 
 #include <ctime>
 
-@ac_google_start_namespace@
+namespace google {
 #include "glog/log_severity.h"
 #include "glog/logging.h"
 #include "glog/vlog_is_on.h"
@@ -62,81 +62,81 @@
 // These will print an almost standard log lines like this to stderr only:
 //   E20200821 211317 file.cc:123] RAW: Failed foo with 22: bad_file
 //   I20200821 211317 file.cc:142] RAW: status is 20
-#define RAW_LOG(severity, ...) \
-  do { \
-    switch (@ac_google_namespace@::GLOG_ ## severity) {  \
-      case 0: \
-        RAW_LOG_INFO(__VA_ARGS__); \
-        break; \
-      case 1: \
-        RAW_LOG_WARNING(__VA_ARGS__); \
-        break; \
-      case 2: \
-        RAW_LOG_ERROR(__VA_ARGS__); \
-        break; \
-      case 3: \
-        RAW_LOG_FATAL(__VA_ARGS__); \
-        break; \
-      default: \
-        break; \
-    } \
+#define RAW_LOG(severity, ...)         \
+  do {                                 \
+    switch (google::GLOG_##severity) { \
+      case 0:                          \
+        RAW_LOG_INFO(__VA_ARGS__);     \
+        break;                         \
+      case 1:                          \
+        RAW_LOG_WARNING(__VA_ARGS__);  \
+        break;                         \
+      case 2:                          \
+        RAW_LOG_ERROR(__VA_ARGS__);    \
+        break;                         \
+      case 3:                          \
+        RAW_LOG_FATAL(__VA_ARGS__);    \
+        break;                         \
+      default:                         \
+        break;                         \
+    }                                  \
   } while (0)
 
 // The following STRIP_LOG testing is performed in the header file so that it's
 // possible to completely compile out the logging code and the log messages.
 #if !defined(STRIP_LOG) || STRIP_LOG == 0
 #define RAW_VLOG(verboselevel, ...) \
-  do { \
+  do {                              \
     if (VLOG_IS_ON(verboselevel)) { \
-      RAW_LOG_INFO(__VA_ARGS__); \
-    } \
+      RAW_LOG_INFO(__VA_ARGS__);    \
+    }                               \
   } while (0)
 #else
 #define RAW_VLOG(verboselevel, ...) RawLogStub__(0, __VA_ARGS__)
-#endif // STRIP_LOG == 0
+#endif  // STRIP_LOG == 0
 
 #if !defined(STRIP_LOG) || STRIP_LOG == 0
-#define RAW_LOG_INFO(...) @ac_google_namespace@::RawLog__(@ac_google_namespace@::GLOG_INFO, \
-                                   __FILE__, __LINE__, __VA_ARGS__)
+#define RAW_LOG_INFO(...) \
+  google::RawLog__(google::GLOG_INFO, __FILE__, __LINE__, __VA_ARGS__)
 #else
-#define RAW_LOG_INFO(...) @ac_google_namespace@::RawLogStub__(0, __VA_ARGS__)
-#endif // STRIP_LOG == 0
+#define RAW_LOG_INFO(...) google::RawLogStub__(0, __VA_ARGS__)
+#endif  // STRIP_LOG == 0
 
 #if !defined(STRIP_LOG) || STRIP_LOG <= 1
-#define RAW_LOG_WARNING(...) @ac_google_namespace@::RawLog__(@ac_google_namespace@::GLOG_WARNING,   \
-                                      __FILE__, __LINE__, __VA_ARGS__)
+#define RAW_LOG_WARNING(...) \
+  google::RawLog__(google::GLOG_WARNING, __FILE__, __LINE__, __VA_ARGS__)
 #else
-#define RAW_LOG_WARNING(...) @ac_google_namespace@::RawLogStub__(0, __VA_ARGS__)
-#endif // STRIP_LOG <= 1
+#define RAW_LOG_WARNING(...) google::RawLogStub__(0, __VA_ARGS__)
+#endif  // STRIP_LOG <= 1
 
 #if !defined(STRIP_LOG) || STRIP_LOG <= 2
-#define RAW_LOG_ERROR(...) @ac_google_namespace@::RawLog__(@ac_google_namespace@::GLOG_ERROR,       \
-                                    __FILE__, __LINE__, __VA_ARGS__)
+#define RAW_LOG_ERROR(...) \
+  google::RawLog__(google::GLOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
 #else
-#define RAW_LOG_ERROR(...) @ac_google_namespace@::RawLogStub__(0, __VA_ARGS__)
-#endif // STRIP_LOG <= 2
+#define RAW_LOG_ERROR(...) google::RawLogStub__(0, __VA_ARGS__)
+#endif  // STRIP_LOG <= 2
 
 #if !defined(STRIP_LOG) || STRIP_LOG <= 3
-#define RAW_LOG_FATAL(...) @ac_google_namespace@::RawLog__(@ac_google_namespace@::GLOG_FATAL,       \
-                                    __FILE__, __LINE__, __VA_ARGS__)
-#else
 #define RAW_LOG_FATAL(...) \
-  do { \
-    @ac_google_namespace@::RawLogStub__(0, __VA_ARGS__);        \
-    exit(EXIT_FAILURE); \
+  google::RawLog__(google::GLOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+#else
+#define RAW_LOG_FATAL(...)                \
+  do {                                    \
+    google::RawLogStub__(0, __VA_ARGS__); \
+    exit(EXIT_FAILURE);                   \
   } while (0)
-#endif // STRIP_LOG <= 3
+#endif  // STRIP_LOG <= 3
 
 // Similar to CHECK(condition) << message,
 // but for low-level modules: we use only RAW_LOG that does not allocate memory.
 // We do not want to provide args list here to encourage this usage:
 //   if (!cond)  RAW_LOG(FATAL, "foo ...", hard_to_compute_args);
 // so that the args are not computed when not needed.
-#define RAW_CHECK(condition, message)                                   \
-  do {                                                                  \
-    if (!(condition)) {                                                 \
-      RAW_LOG(FATAL, "Check %s failed: %s", #condition, message);       \
-    }                                                                   \
+#define RAW_CHECK(condition, message)                             \
+  do {                                                            \
+    if (!(condition)) {                                           \
+      RAW_LOG(FATAL, "Check %s failed: %s", #condition, message); \
+    }                                                             \
   } while (0)
 
 // Debug versions of RAW_LOG and RAW_CHECK
@@ -147,12 +147,10 @@
 
 #else  // NDEBUG
 
-#define RAW_DLOG(severity, ...)                                 \
-  while (false)                                                 \
-    RAW_LOG(severity, __VA_ARGS__)
+#define RAW_DLOG(severity, ...) \
+  while (false) RAW_LOG(severity, __VA_ARGS__)
 #define RAW_DCHECK(condition, message) \
-  while (false) \
-    RAW_CHECK(condition, message)
+  while (false) RAW_CHECK(condition, message)
 
 #endif  // NDEBUG
 
@@ -162,8 +160,7 @@
 
 // Stub log function used to work around for unused variable warnings when
 // building with STRIP_LOG > 0.
-static inline void RawLogStub__(int /* ignored */, ...) {
-}
+static inline void RawLogStub__(int /* ignored */, ...) {}
 
 // Helper function to implement RAW_LOG and RAW_VLOG
 // Logs format... at "severity" level, reporting it
@@ -171,8 +168,12 @@ static inline void RawLogStub__(int /* ignored */, ...) {
 // This does not allocate memory or acquire locks.
 GLOG_EXPORT void RawLog__(LogSeverity severity, const char* file, int line,
                           const char* format, ...)
-    @ac_cv___attribute___printf_4_5@;
-
-@ac_google_end_namespace@
+#if defined(__has_attribute)
+#if __has_attribute(used)
+    __attribute__((__format__(__printf__, 4, 5)))
+#endif
+#endif
+    ;
+}  // namespace google
 
 #endif  // GLOG_RAW_LOGGING_H

--- a/src/glog/stl_logging.h
+++ b/src/glog/stl_logging.h
@@ -52,79 +52,78 @@
 // Forward declare these two, and define them after all the container streams
 // operators so that we can recurse from pair -> container -> container -> pair
 // properly.
-template<class First, class Second>
+template <class First, class Second>
 std::ostream& operator<<(std::ostream& out, const std::pair<First, Second>& p);
 
-@ac_google_start_namespace@
+namespace google {
 
-template<class Iter>
+template <class Iter>
 void PrintSequence(std::ostream& out, Iter begin, Iter end);
 
-@ac_google_end_namespace@
-#define OUTPUT_TWO_ARG_CONTAINER(Sequence) \
-template<class T1, class T2> \
-inline std::ostream& operator<<(std::ostream& out, \
-                                const Sequence<T1, T2>& seq) { \
-  @ac_google_namespace@::PrintSequence(out, seq.begin(), seq.end()); \
-  return out; \
 }
+#define OUTPUT_TWO_ARG_CONTAINER(Sequence)                       \
+  template <class T1, class T2>                                  \
+  inline std::ostream& operator<<(std::ostream& out,             \
+                                  const Sequence<T1, T2>& seq) { \
+    google::PrintSequence(out, seq.begin(), seq.end());          \
+    return out;                                                  \
+  }
 
-    OUTPUT_TWO_ARG_CONTAINER(std::vector) OUTPUT_TWO_ARG_CONTAINER(std::deque)
-        OUTPUT_TWO_ARG_CONTAINER(std::list)
-
+OUTPUT_TWO_ARG_CONTAINER(std::vector)
+OUTPUT_TWO_ARG_CONTAINER(std::deque)
+OUTPUT_TWO_ARG_CONTAINER(std::list)
 #undef OUTPUT_TWO_ARG_CONTAINER
 
-#define OUTPUT_THREE_ARG_CONTAINER(Sequence) \
-template<class T1, class T2, class T3> \
-inline std::ostream& operator<<(std::ostream& out, \
-                                const Sequence<T1, T2, T3>& seq) { \
-  @ac_google_namespace@::PrintSequence(out, seq.begin(), seq.end()); \
-  return out; \
-}
+#define OUTPUT_THREE_ARG_CONTAINER(Sequence)                         \
+  template <class T1, class T2, class T3>                            \
+  inline std::ostream& operator<<(std::ostream& out,                 \
+                                  const Sequence<T1, T2, T3>& seq) { \
+    google::PrintSequence(out, seq.begin(), seq.end());              \
+    return out;                                                      \
+  }
 
-            OUTPUT_THREE_ARG_CONTAINER(std::set) OUTPUT_THREE_ARG_CONTAINER(
-                std::multiset)
+OUTPUT_THREE_ARG_CONTAINER(std::set)
+OUTPUT_THREE_ARG_CONTAINER(std::multiset)
 
 #undef OUTPUT_THREE_ARG_CONTAINER
 
-#define OUTPUT_FOUR_ARG_CONTAINER(Sequence) \
-template<class T1, class T2, class T3, class T4> \
-inline std::ostream& operator<<(std::ostream& out, \
-                                const Sequence<T1, T2, T3, T4>& seq) { \
-  @ac_google_namespace@::PrintSequence(out, seq.begin(), seq.end()); \
-  return out; \
-}
+#define OUTPUT_FOUR_ARG_CONTAINER(Sequence)                              \
+  template <class T1, class T2, class T3, class T4>                      \
+  inline std::ostream& operator<<(std::ostream& out,                     \
+                                  const Sequence<T1, T2, T3, T4>& seq) { \
+    google::PrintSequence(out, seq.begin(), seq.end());                  \
+    return out;                                                          \
+  }
 
-                OUTPUT_FOUR_ARG_CONTAINER(std::map) OUTPUT_FOUR_ARG_CONTAINER(
-                    std::multimap) OUTPUT_FOUR_ARG_CONTAINER(std::unordered_set)
-                    OUTPUT_FOUR_ARG_CONTAINER(std::unordered_multiset)
-
+OUTPUT_FOUR_ARG_CONTAINER(std::map)
+OUTPUT_FOUR_ARG_CONTAINER(std::multimap)
+OUTPUT_FOUR_ARG_CONTAINER(std::unordered_set)
+OUTPUT_FOUR_ARG_CONTAINER(std::unordered_multiset)
 #undef OUTPUT_FOUR_ARG_CONTAINER
 
-#define OUTPUT_FIVE_ARG_CONTAINER(Sequence) \
-template<class T1, class T2, class T3, class T4, class T5> \
-inline std::ostream& operator<<(std::ostream& out, \
-                                const Sequence<T1, T2, T3, T4, T5>& seq) { \
-  @ac_google_namespace@::PrintSequence(out, seq.begin(), seq.end()); \
-  return out; \
-}
+#define OUTPUT_FIVE_ARG_CONTAINER(Sequence)                                  \
+  template <class T1, class T2, class T3, class T4, class T5>                \
+  inline std::ostream& operator<<(std::ostream& out,                         \
+                                  const Sequence<T1, T2, T3, T4, T5>& seq) { \
+    google::PrintSequence(out, seq.begin(), seq.end());                      \
+    return out;                                                              \
+  }
 
-                        OUTPUT_FIVE_ARG_CONTAINER(std::unordered_map)
-                            OUTPUT_FIVE_ARG_CONTAINER(std::unordered_multimap)
+OUTPUT_FIVE_ARG_CONTAINER(std::unordered_map)
+OUTPUT_FIVE_ARG_CONTAINER(std::unordered_multimap)
 
 #undef OUTPUT_FIVE_ARG_CONTAINER
 
-                                template <class First, class Second>
-                                inline std::ostream& operator<<(
-                                    std::ostream& out,
-                                    const std::pair<First, Second>& p) {
+template <class First, class Second>
+inline std::ostream& operator<<(std::ostream& out,
+                                const std::pair<First, Second>& p) {
   out << '(' << p.first << ", " << p.second << ')';
   return out;
 }
 
-@ac_google_start_namespace@
+namespace google {
 
-template<class Iter>
+template <class Iter>
 inline void PrintSequence(std::ostream& out, Iter begin, Iter end) {
   // Output at most 100 elements -- appropriate if used for logging.
   for (int i = 0; begin != end && i < 100; ++i, ++begin) {
@@ -136,7 +135,7 @@ inline void PrintSequence(std::ostream& out, Iter begin, Iter end) {
   }
 }
 
-@ac_google_end_namespace@
+}  // namespace google
 
 // Note that this is technically undefined behavior! We are adding things into
 // the std namespace for a reason though -- we are providing new operations on
@@ -162,6 +161,8 @@ inline void PrintSequence(std::ostream& out, Iter begin, Iter end) {
 // move all of the *definitions* into namespace std, bet we need to ensure no
 // one references them first. This lets us take that step. We cannot define them
 // in both because that would create ambiguous overloads when both are found.
-namespace std { using ::operator<<; }
+namespace std {
+using ::operator<<;
+}
 
 #endif  // UTIL_GTL_STL_LOGGING_INL_H_

--- a/src/glog/vlog_is_on.h
+++ b/src/glog/vlog_is_on.h
@@ -72,14 +72,15 @@
 // it's either FLAGS_v or an appropriate internal variable
 // matching the current source file that represents results of
 // parsing of --vmodule flag and/or SetVLOGLevel calls.
-#define VLOG_IS_ON(verboselevel)                                \
-  __extension__  \
-  ({ static @ac_google_namespace@::SiteFlag vlocal__ = {nullptr, nullptr, 0, nullptr};       \
-     GLOG_IFDEF_THREAD_SANITIZER( \
-             AnnotateBenignRaceSized(__FILE__, __LINE__, &vlocal__, sizeof(@ac_google_namespace@::SiteFlag), "")); \
-     @ac_google_namespace@::int32 verbose_level__ = (verboselevel);                    \
-     (vlocal__.level == nullptr ? @ac_google_namespace@::InitVLOG3__(&vlocal__, &FLAGS_v, \
-                        __FILE__, verbose_level__) : *vlocal__.level >= verbose_level__); \
+#define VLOG_IS_ON(verboselevel)                                               \
+  __extension__({                                                              \
+    static google::SiteFlag vlocal__ = {nullptr, nullptr, 0, nullptr};         \
+    GLOG_IFDEF_THREAD_SANITIZER(AnnotateBenignRaceSized(                       \
+        __FILE__, __LINE__, &vlocal__, sizeof(google::SiteFlag), ""));         \
+    google::int32 verbose_level__ = (verboselevel);                            \
+    (vlocal__.level == nullptr                                                 \
+         ? google::InitVLOG3__(&vlocal__, &FLAGS_v, __FILE__, verbose_level__) \
+         : *vlocal__.level >= verbose_level__);                                \
   })
 #else
 // GNU extensions not available, so we do not support --vmodule.
@@ -100,7 +101,7 @@ extern GLOG_EXPORT int SetVLOGLevel(const char* module_pattern, int log_level);
 // Various declarations needed for VLOG_IS_ON above: =========================
 
 struct SiteFlag {
-  @ac_google_namespace@::int32* level;
+  google::int32* level;
   const char* base_name;
   std::size_t base_len;
   SiteFlag* next;
@@ -114,9 +115,9 @@ struct SiteFlag {
 //   verbose_level is the argument to VLOG_IS_ON
 // We will return the return value for VLOG_IS_ON
 // and if possible set *site_flag appropriately.
-extern GLOG_EXPORT bool InitVLOG3__(
-    @ac_google_namespace@::SiteFlag* site_flag,
-    @ac_google_namespace@::int32* site_default, const char* fname,
-    @ac_google_namespace@::int32 verbose_level);
+extern GLOG_EXPORT bool InitVLOG3__(google::SiteFlag* site_flag,
+                                    google::int32* site_default,
+                                    const char* fname,
+                                    google::int32 verbose_level);
 
 #endif  // BASE_VLOG_IS_ON_H_

--- a/src/googletest.h
+++ b/src/googletest.h
@@ -68,11 +68,11 @@ using std::map;
 using std::string;
 using std::vector;
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 extern GLOG_EXPORT void (*g_logging_fail_func)();
 
-_END_GOOGLE_NAMESPACE_
+}
 
 #undef GLOG_EXPORT
 #define GLOG_EXPORT
@@ -119,7 +119,7 @@ DEFINE_int32(benchmark_iters, 100000, "Number of iterations per benchmark");
 using testing::InitGoogleTest;
 #else
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 void InitGoogleTest(int*, char**);
 
@@ -213,11 +213,11 @@ static inline int RUN_ALL_TESTS() {
   return 0;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif  // ! HAVE_LIB_GTEST
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 static bool g_called_abort;
 static jmp_buf g_jmp_buf;
@@ -556,7 +556,7 @@ static inline bool MungeAndDiffTestStdout(const string& golden_filename) {
 }
 
 // Save flags used from logging_unittest.cc.
-#ifndef HAVE_LIB_GFLAGS
+#ifndef GLOG_USE_GFLAGS
 struct FlagSaver {
   FlagSaver()
       : v_(FLAGS_v),
@@ -638,11 +638,11 @@ static inline void SleepForMilliseconds(unsigned t) {
 
 void (*g_new_hook)() = nullptr;
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 void* operator new(size_t size, const std::nothrow_t&) noexcept {
-  if (GOOGLE_NAMESPACE::g_new_hook) {
-    GOOGLE_NAMESPACE::g_new_hook();
+  if (google::g_new_hook) {
+    google::g_new_hook();
   }
   return malloc(size);
 }

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -62,7 +62,7 @@
 
 DECLARE_string(log_backtrace_at);  // logging.cc
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 #include <gflags/gflags.h>
 using namespace GFLAGS_NAMESPACE;
 #endif
@@ -71,28 +71,28 @@ using namespace GFLAGS_NAMESPACE;
 #include <gmock/gmock.h>
 #include "mock-log.h"
 // Introduce several symbols from gmock.
+using google::glog_testing::ScopedMockLog;
 using testing::_;
+using testing::AllOf;
 using testing::AnyNumber;
 using testing::HasSubstr;
-using testing::AllOf;
-using testing::StrNe;
-using testing::StrictMock;
 using testing::InitGoogleMock;
-using GOOGLE_NAMESPACE::glog_testing::ScopedMockLog;
+using testing::StrictMock;
+using testing::StrNe;
 #endif
 
 using namespace std;
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 // Some non-advertised functions that we want to test or use.
-_START_GOOGLE_NAMESPACE_
+namespace google {
 namespace base {
 namespace internal {
 bool GetExitOnDFatal();
 void SetExitOnDFatal(bool value);
 }  // namespace internal
 }  // namespace base
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 static void TestLogging(bool check_counts);
 static void TestRawLogging();
@@ -239,7 +239,7 @@ int main(int argc, char **argv) {
   InitGoogleMock(&argc, argv);
 #endif
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
   ParseCommandLineFlags(&argc, &argv, true);
 #endif
 
@@ -1104,14 +1104,14 @@ static void TestLogPeriodically() {
   }
 }
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 namespace glog_internal_namespace_ {
 extern  // in logging.cc
 bool SafeFNMatch_(const char* pattern, size_t patt_len,
                   const char* str, size_t str_len);
 } // namespace glog_internal_namespace_
 using glog_internal_namespace_::SafeFNMatch_;
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 static bool WrapSafeFNMatch(string pattern, string str) {
   pattern += "abc";

--- a/src/mock-log.h
+++ b/src/mock-log.h
@@ -35,7 +35,7 @@
 #ifndef GLOG_SRC_MOCK_LOG_H_
 #define GLOG_SRC_MOCK_LOG_H_
 
-// For GOOGLE_NAMESPACE. This must go first so we get _XOPEN_SOURCE.
+// For google. This must go first so we get _XOPEN_SOURCE.
 #include <gmock/gmock.h>
 
 #include <string>
@@ -43,7 +43,7 @@
 #include "glog/logging.h"
 #include "utilities.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 namespace glog_testing {
 
 // A ScopedMockLog object intercepts LOG() messages issued during its
@@ -64,7 +64,7 @@ namespace glog_testing {
 //
 //     Foo();  // Exercises the code under test.
 //   }
-class ScopedMockLog : public GOOGLE_NAMESPACE::LogSink {
+class ScopedMockLog : public google::LogSink {
  public:
   // When a ScopedMockLog object is constructed, it starts to
   // intercept logs.
@@ -86,9 +86,9 @@ class ScopedMockLog : public GOOGLE_NAMESPACE::LogSink {
   // for messages from different threads. In fact, if the same or multiple
   // expectations are matched on two threads concurrently, their actions will
   // be executed concurrently as well and may interleave.
-  MOCK_METHOD3(Log, void(GOOGLE_NAMESPACE::LogSeverity severity,
-                         const std::string& file_path,
-                         const std::string& message));
+  MOCK_METHOD3(Log,
+               void(google::LogSeverity severity, const std::string& file_path,
+                    const std::string& message));
 
  private:
   // Implements the send() virtual function in class LogSink.
@@ -112,7 +112,7 @@ class ScopedMockLog : public GOOGLE_NAMESPACE::LogSink {
   // be running simultaneously, we ensure thread-safety of the exchange between
   // send() and WaitTillSent(), and that for each message, LOG(), send(),
   // WaitTillSent() and Log() are executed in the same thread.
-  void send(GOOGLE_NAMESPACE::LogSeverity severity, const char* full_filename,
+  void send(google::LogSeverity severity, const char* full_filename,
             const char* /*base_filename*/, int /*line*/,
             const LogMessageTime& /*logmsgtime*/, const char* message,
             size_t message_len) override {
@@ -141,7 +141,7 @@ class ScopedMockLog : public GOOGLE_NAMESPACE::LogSink {
   // All relevant information about a logged message that needs to be passed
   // from send() to WaitTillSent().
   struct MessageInfo {
-    GOOGLE_NAMESPACE::LogSeverity severity;
+    google::LogSeverity severity;
     std::string file_path;
     std::string message;
   };
@@ -149,6 +149,6 @@ class ScopedMockLog : public GOOGLE_NAMESPACE::LogSink {
 };
 
 }  // namespace glog_testing
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif  // GLOG_SRC_MOCK_LOG_H_

--- a/src/mock-log_unittest.cc
+++ b/src/mock-log_unittest.cc
@@ -40,10 +40,10 @@
 
 namespace {
 
-using GOOGLE_NAMESPACE::GLOG_ERROR;
-using GOOGLE_NAMESPACE::GLOG_INFO;
-using GOOGLE_NAMESPACE::GLOG_WARNING;
-using GOOGLE_NAMESPACE::glog_testing::ScopedMockLog;
+using google::GLOG_ERROR;
+using google::GLOG_INFO;
+using google::GLOG_WARNING;
+using google::glog_testing::ScopedMockLog;
 using std::string;
 using testing::_;
 using testing::EndsWith;
@@ -100,7 +100,7 @@ TEST(ScopedMockLogTest, LogDuringIntercept) {
 }  // namespace
 
 int main(int argc, char **argv) {
-  GOOGLE_NAMESPACE::InitGoogleLogging(argv[0]);
+  google::InitGoogleLogging(argv[0]);
   testing::InitGoogleTest(&argc, argv);
   testing::InitGoogleMock(&argc, argv);
 

--- a/src/raw_logging.cc
+++ b/src/raw_logging.cc
@@ -70,7 +70,7 @@
 #define safe_write(fd, s, len) write(fd, s, len)
 #endif
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 #if defined(__GNUC__)
 #define GLOG_ATTRIBUTE_FORMAT(archetype, stringIndex, firstToCheck) \
@@ -179,4 +179,4 @@ void RawLog__(LogSeverity severity, const char* file, int line,
   }
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2008, Google Inc.
+// Copyright (c) 2023, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@
 //
 // Implementation of InstallFailureSignalHandler().
 
+#include <algorithm>
 #include <csignal>
 #include <ctime>
 
@@ -38,15 +39,18 @@
 #include "stacktrace.h"
 #include "symbolize.h"
 #include "utilities.h"
+
 #ifdef HAVE_UCONTEXT_H
 # include <ucontext.h>
 #endif
 #ifdef HAVE_SYS_UCONTEXT_H
 # include <sys/ucontext.h>
 #endif
-#include <algorithm>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 namespace {
 
@@ -409,4 +413,4 @@ void InstallFailureWriter(void (*writer)(const char* data, size_t size)) {
 #endif  // HAVE_SIGACTION
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/signalhandler_unittest.cc
+++ b/src/signalhandler_unittest.cc
@@ -44,12 +44,12 @@
 
 #include "glog/logging.h"
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 #include <gflags/gflags.h>
 using namespace GFLAGS_NAMESPACE;
 #endif
 
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 static void* DieInThread(void*) {
   // We assume pthread_t is an integral number or a pointer, rather
@@ -75,7 +75,7 @@ static void WriteToStdout(const char* data, size_t size) {
 int main(int argc, char **argv) {
 #if defined(HAVE_STACKTRACE) && defined(HAVE_SYMBOLIZE)
   InitGoogleLogging(argv[0]);
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
   ParseCommandLineFlags(&argc, &argv, true);
 #endif
   InstallFailureSignalHandler();

--- a/src/stacktrace.h
+++ b/src/stacktrace.h
@@ -36,7 +36,7 @@
 #include "config.h"
 #include "glog/logging.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // This is similar to the GetStackFrames routine, except that it returns
 // the stack trace only, and not the stack frame sizes as well.
@@ -56,6 +56,6 @@ _START_GOOGLE_NAMESPACE_
 // "result" must not be nullptr.
 GLOG_EXPORT int GetStackTrace(void** result, int max_depth, int skip_count);
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif  // BASE_STACKTRACE_H_

--- a/src/stacktrace_generic-inl.h
+++ b/src/stacktrace_generic-inl.h
@@ -37,7 +37,7 @@
 
 #include "stacktrace.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // If you change this function, also change GetStackFrames below.
 int GetStackTrace(void** result, int max_depth, int skip_count) {
@@ -61,4 +61,4 @@ int GetStackTrace(void** result, int max_depth, int skip_count) {
   return result_count;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/stacktrace_libunwind-inl.h
+++ b/src/stacktrace_libunwind-inl.h
@@ -40,7 +40,7 @@ extern "C" {
 #include "glog/raw_logging.h"
 #include "stacktrace.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // Sometimes, we can try to get a stack trace from within a stack
 // trace, because libunwind can call mmap (maybe indirectly via an
@@ -90,4 +90,4 @@ int GetStackTrace(void** result, int max_depth, int skip_count) {
   return n;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/stacktrace_powerpc-inl.h
+++ b/src/stacktrace_powerpc-inl.h
@@ -40,7 +40,7 @@
 
 #include "stacktrace.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // Given a pointer to a stack frame, locate and return the calling
 // stackframe, or return nullptr if no stackframe can be found. Perform sanity
@@ -130,4 +130,4 @@ int GetStackTrace(void** result, int max_depth, int skip_count) {
   return n;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/stacktrace_unittest.cc
+++ b/src/stacktrace_unittest.cc
@@ -41,7 +41,7 @@
 # include <execinfo.h>
 #endif
 
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 #ifdef HAVE_STACKTRACE
 

--- a/src/stacktrace_unwind-inl.h
+++ b/src/stacktrace_unwind-inl.h
@@ -35,7 +35,7 @@
 
 #include "stacktrace.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 struct trace_arg_t {
   void **result;
@@ -101,4 +101,4 @@ int GetStackTrace(void** result, int max_depth, int skip_count) {
   return targ.count;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/stacktrace_windows-inl.h
+++ b/src/stacktrace_windows-inl.h
@@ -36,7 +36,7 @@
 #include "stacktrace.h"
 #include <dbghelp.h>
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 int GetStackTrace(void** result, int max_depth, int skip_count) {
   if (max_depth > 64) {
@@ -48,4 +48,4 @@ int GetStackTrace(void** result, int max_depth, int skip_count) {
                                static_cast<DWORD>(max_depth), result, nullptr);
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/stacktrace_x86-inl.h
+++ b/src/stacktrace_x86-inl.h
@@ -42,7 +42,7 @@
 
 #include "stacktrace.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // Given a pointer to a stack frame, locate and return the calling
 // stackframe, or return nullptr if no stackframe can be found. Perform sanity
@@ -156,4 +156,4 @@ int GetStackTrace(void** result, int max_depth, int skip_count) {
   return n;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google

--- a/src/striplog_unittest.cc
+++ b/src/striplog_unittest.cc
@@ -44,7 +44,7 @@
 GLOG_DEFINE_bool(check_mode, false, "Prints 'opt' or 'dbg'");
 
 using std::string;
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 int CheckNoReturn(bool b) {
   string s;

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2006, Google Inc.
+// Copyright (c) 2023, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@
 #include "symbolize.h"
 #include "demangle.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // We don't use assert() since it's not guaranteed to be
 // async-signal-safe.  Instead we define a minimal assertion
@@ -106,7 +106,7 @@ static ATTRIBUTE_NOINLINE void DemangleInplace(char *out, size_t out_size) {
   }
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #if defined(__ELF__)
 
@@ -138,7 +138,7 @@ _END_GOOGLE_NAMESPACE_
 // Re-runs fn until it doesn't cause EINTR.
 #define NO_INTR(fn)   do {} while ((fn) < 0 && errno == EINTR)
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // Read up to "count" bytes from "offset" in the file pointed by file
 // descriptor "fd" into the buffer starting at "buf" while handling short reads
@@ -833,14 +833,14 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
   return true;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #elif defined(GLOG_OS_MACOSX) && defined(HAVE_DLADDR)
 
 #include <dlfcn.h>
 #include <cstring>
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
                                                     size_t out_size) {
@@ -858,7 +858,7 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
   return false;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #elif defined(GLOG_OS_WINDOWS) || defined(GLOG_OS_CYGWIN)
 
@@ -869,7 +869,7 @@ _END_GOOGLE_NAMESPACE_
 #pragma comment(lib, "dbghelp")
 #endif
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 class SymInitializer {
 public:
@@ -923,19 +923,19 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(void *pc, char *out,
   return false;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #else
 # error BUG: HAVE_SYMBOLIZE was wrongly set
 #endif
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 bool Symbolize(void *pc, char *out, size_t out_size) {
   return SymbolizeAndDemangle(pc, out, out_size);
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #else  /* HAVE_SYMBOLIZE */
 
@@ -943,7 +943,7 @@ _END_GOOGLE_NAMESPACE_
 
 #include "config.h"
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // TODO: Support other environments.
 bool Symbolize(void* /*pc*/, char* /*out*/, size_t /*out_size*/) {
@@ -951,6 +951,6 @@ bool Symbolize(void* /*pc*/, char* /*out*/, size_t /*out_size*/) {
   return false;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif

--- a/src/symbolize.h
+++ b/src/symbolize.h
@@ -92,18 +92,18 @@
 # endif
 #endif
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // Gets the section header for the given name, if it exists. Returns true on
 // success. Otherwise, returns false.
 bool GetSectionHeaderByName(int fd, const char *name, size_t name_len,
                             ElfW(Shdr) *out);
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif  /* __ELF__ */
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // Restrictions on the callbacks that follow:
 //  - The callbacks must not use heaps but only use stacks.
@@ -135,11 +135,11 @@ using SymbolizeOpenObjectFileCallback = int (*)(uint64_t, uint64_t &,
 void InstallSymbolizeOpenObjectFileCallback(
     SymbolizeOpenObjectFileCallback callback);
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 // Symbolizes a program counter.  On success, returns true and write the
 // symbol name to "out".  The symbol name is demangled if possible
@@ -147,6 +147,6 @@ _START_GOOGLE_NAMESPACE_
 // returns false.
 GLOG_EXPORT bool Symbolize(void* pc, char* out, size_t out_size);
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif  // BASE_SYMBOLIZE_H_

--- a/src/symbolize_unittest.cc
+++ b/src/symbolize_unittest.cc
@@ -41,13 +41,13 @@
 #include "googletest.h"
 #include "utilities.h"
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 #include <gflags/gflags.h>
 using namespace GFLAGS_NAMESPACE;
 #endif
 
 using namespace std;
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 // Avoid compile error due to "cast between pointer-to-function and
 // pointer-to-object is an extension" warnings.

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -62,7 +62,7 @@
 
 using std::string;
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 static const char* g_program_invocation_short_name = nullptr;
 
@@ -70,7 +70,7 @@ bool IsGoogleLoggingInitialized() {
   return g_program_invocation_short_name != nullptr;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 // The following APIs are all internal.
 #ifdef HAVE_STACKTRACE
@@ -82,7 +82,7 @@ _END_GOOGLE_NAMESPACE_
 GLOG_DEFINE_bool(symbolize_stacktrace, true,
                  "Symbolize the stack trace in the tombstone");
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 using DebugWriter = void(const char*, void*);
 
@@ -177,11 +177,11 @@ DumpStackTraceAndExit() {
   abort();
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 #endif  // HAVE_STACKTRACE
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 namespace glog_internal_namespace_ {
 
@@ -386,7 +386,7 @@ void ShutdownGoogleLoggingUtilities() {
 
 }  // namespace glog_internal_namespace_
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
 // Make an implementation of stacktrace compiled.
 #ifdef STACKTRACE_H

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -63,6 +63,19 @@
 
 #include "config.h"
 
+#if defined(HAVE_UNISTD_H)
+#include <unistd.h>
+#endif
+
+#if !defined(HAVE_SSIZE_T)
+#if defined(GLOG_OS_WINDOWS)
+#include <basetsd.h>
+using ssize_t = SSIZE_T;
+#else
+using ssize_t = std::ptrdiff_t;
+#endif
+#endif
+
 // There are three different ways we can try to get the stack trace:
 //
 // 1) The libunwind library.  This is still in development, and as a
@@ -127,17 +140,25 @@
 # define ARRAYSIZE(a) (sizeof(a) / sizeof(*(a)))
 #endif
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 namespace glog_internal_namespace_ {
 
-#ifdef HAVE___ATTRIBUTE__
+#if defined(__has_attribute)
+#if __has_attribute(noinline)
 # define ATTRIBUTE_NOINLINE __attribute__ ((noinline))
 # define HAVE_ATTRIBUTE_NOINLINE
-#elif defined(GLOG_OS_WINDOWS)
+#endif
+#endif
+
+#if !defined(HAVE_ATTRIBUTE_NOINLINE)
+#if defined(GLOG_OS_WINDOWS)
 # define ATTRIBUTE_NOINLINE __declspec(noinline)
 # define HAVE_ATTRIBUTE_NOINLINE
-#else
+#endif
+#endif
+
+#if !defined(HAVE_ATTRIBUTE_NOINLINE)
 # define ATTRIBUTE_NOINLINE
 #endif
 
@@ -209,8 +230,8 @@ void ShutdownGoogleLoggingUtilities();
 
 }  // namespace glog_internal_namespace_
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google
 
-using namespace GOOGLE_NAMESPACE::glog_internal_namespace_;
+using namespace google::glog_internal_namespace_;
 
 #endif  // UTILITIES_H__

--- a/src/utilities_unittest.cc
+++ b/src/utilities_unittest.cc
@@ -33,12 +33,12 @@
 #include "glog/logging.h"
 #include "googletest.h"
 
-#ifdef HAVE_LIB_GFLAGS
+#ifdef GLOG_USE_GFLAGS
 #include <gflags/gflags.h>
 using namespace GFLAGS_NAMESPACE;
 #endif
 
-using namespace GOOGLE_NAMESPACE;
+using namespace google;
 
 TEST(utilities, sync_val_compare_and_swap) {
   bool now_entering = false;

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -58,7 +58,7 @@ GLOG_DEFINE_string(vmodule, "", "per-module verbose level."
 " (that is, name ignoring .cc/.h./-inl.h)."
 " <log level> overrides any value given by --v.");
 
-_START_GOOGLE_NAMESPACE_
+namespace google {
 
 namespace glog_internal_namespace_ {
 
@@ -291,4 +291,4 @@ bool InitVLOG3__(SiteFlag* site_flag, int32* level_default,
   return *site_flag_value >= verbose_level;
 }
 
-_END_GOOGLE_NAMESPACE_
+}  // namespace google


### PR DESCRIPTION
Promote generated headers to regular headers. This enables direct editing of corresponding files and running automatic source code formatting and static analysis tools, such as clang-format and clang-tidy on the whole project which previously was not straightforward.

cc @drigz 