### PR TITLE
fix: add missing `gmtime_r` check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,6 +313,7 @@ endif (WITH_SYMBOLIZE)
 # building the library.
 add_compile_definitions (GLOG_NO_SYMBOLIZE_DETECTION)
 
+check_cxx_symbol_exists (gmtime_r "cstdlib;ctime" HAVE_GMTIME_R)
 check_cxx_symbol_exists (localtime_r "cstdlib;ctime" HAVE_LOCALTIME_R)
 
 set (SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})


### PR DESCRIPTION
909069ea8237b7261e21c47607fc89a16610a8f9 introduced optional `gmtime_r` support but did implement the function's availability check.