### PR TITLE
feat(cleanup): use chrono

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -710,7 +710,16 @@ To enable the log cleaner:
 
 .. code:: cpp
 
-   google::EnableLogCleaner(3); // keep your logs for 3 days
+   using namespace std::chrono_literals;
+   google::EnableLogCleaner(24h * 3); // keep your logs for 3 days
+
+
+In C++20 (and later) this can be shortened to:
+
+.. code:: cpp
+
+   using namespace std::chrono_literals;
+   google::EnableLogCleaner(3d); // keep your logs for 3 days
 
 And then glog will check if there are overdue logs whenever a flush is
 performed. In this example, any log file from your project whose last

--- a/cmake/RunCleanerTest1.cmake
+++ b/cmake/RunCleanerTest1.cmake
@@ -7,16 +7,20 @@ foreach (iter RANGE 1 ${RUNS})
   if (NOT _RESULT EQUAL 0)
     message (FATAL_ERROR "Failed to run logcleanup_unittest (error: ${_RESULT})")
   endif (NOT _RESULT EQUAL 0)
-
-  # Ensure the log files to have different modification timestamps such that
-  # exactly one log file remains at the end. Otherwise all log files will be
-  # retained.
-  execute_process (COMMAND ${CMAKE_COMMAND} -E sleep 1)
 endforeach (iter)
 
 file (GLOB LOG_FILES ${TEST_DIR}/*.foobar)
 list (LENGTH LOG_FILES NUM_FILES)
 
-if (NOT NUM_FILES EQUAL 1)
-  message (SEND_ERROR "Expected 1 log file in log directory but found ${NUM_FILES}")
-endif (NOT NUM_FILES EQUAL 1)
+if (WIN32)
+  # On Windows open files cannot be removed and will result in a permission
+  # denied error while unlinking such file. Therefore, the last file will be
+  # retained.
+  set (_expected 1)
+ else (WIN32)
+  set (_expected 0)
+endif (WIN32)
+
+if (NOT NUM_FILES EQUAL _expected)
+  message (SEND_ERROR "Expected ${_expected} log file in log directory but found ${NUM_FILES}")
+endif (NOT NUM_FILES EQUAL _expected)

--- a/cmake/RunCleanerTest2.cmake
+++ b/cmake/RunCleanerTest2.cmake
@@ -7,16 +7,20 @@ foreach (iter RANGE 1 ${RUNS})
   if (NOT _RESULT EQUAL 0)
     message (FATAL_ERROR "Failed to run logcleanup_unittest (error: ${_RESULT})")
   endif (NOT _RESULT EQUAL 0)
-
-  # Ensure the log files to have different modification timestamps such that
-  # exactly one log file remains at the end. Otherwise all log files will be
-  # retained.
-  execute_process (COMMAND ${CMAKE_COMMAND} -E sleep 1)
 endforeach (iter)
 
 file (GLOB LOG_FILES ${TEST_DIR}/test_cleanup_*.barfoo)
 list (LENGTH LOG_FILES NUM_FILES)
 
-if (NOT NUM_FILES EQUAL 1)
-  message (SEND_ERROR "Expected 1 log file in build directory ${TEST_DIR} but found ${NUM_FILES}")
-endif (NOT NUM_FILES EQUAL 1)
+if (WIN32)
+  # On Windows open files cannot be removed and will result in a permission
+  # denied error while unlinking such file. Therefore, the last file will be
+  # retained.
+  set (_expected 1)
+ else (WIN32)
+  set (_expected 0)
+endif (WIN32)
+
+if (NOT NUM_FILES EQUAL _expected)
+  message (SEND_ERROR "Expected ${_expected} log file in log directory but found ${NUM_FILES}")
+endif (NOT NUM_FILES EQUAL _expected)

--- a/cmake/RunCleanerTest3.cmake
+++ b/cmake/RunCleanerTest3.cmake
@@ -10,19 +10,23 @@ foreach (iter RANGE 1 ${RUNS})
   if (NOT _RESULT EQUAL 0)
     message (FATAL_ERROR "Failed to run logcleanup_unittest (error: ${_RESULT})")
   endif (NOT _RESULT EQUAL 0)
-
-  # Ensure the log files to have different modification timestamps such that
-  # exactly one log file remains at the end. Otherwise all log files will be
-  # retained.
-  execute_process (COMMAND ${CMAKE_COMMAND} -E sleep 2)
 endforeach (iter)
 
 file (GLOB LOG_FILES ${TEST_DIR}/${TEST_SUBDIR}/test_cleanup_*.relativefoo)
 list (LENGTH LOG_FILES NUM_FILES)
 
-if (NOT NUM_FILES EQUAL 1)
-  message (SEND_ERROR "Expected 1 log file in build directory ${TEST_DIR}${TEST_SUBDIR} but found ${NUM_FILES}")
-endif (NOT NUM_FILES EQUAL 1)
+if (WIN32)
+  # On Windows open files cannot be removed and will result in a permission
+  # denied error while unlinking such file. Therefore, the last file will be
+  # retained.
+  set (_expected 1)
+ else (WIN32)
+  set (_expected 0)
+endif (WIN32)
+
+if (NOT NUM_FILES EQUAL _expected)
+  message (SEND_ERROR "Expected ${_expected} log file in build directory ${TEST_DIR}${TEST_SUBDIR} but found ${NUM_FILES}")
+endif (NOT NUM_FILES EQUAL _expected)
 
 # Remove the subdirectory required by this unit test.
 file (REMOVE_RECURSE ${TEST_DIR}/${TEST_SUBDIR})

--- a/src/cleanup_immediately_unittest.cc
+++ b/src/cleanup_immediately_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Google Inc.
+// Copyright (c) 2024, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -55,8 +55,9 @@ using testing::StrNe;
 using namespace google;
 
 TEST(CleanImmediately, logging) {
+  using namespace std::chrono_literals;
   google::SetLogFilenameExtension(".foobar");
-  google::EnableLogCleaner(0);
+  google::EnableLogCleaner(0h);
 
   for (unsigned i = 0; i < 1000; ++i) {
     LOG(INFO) << "cleanup test";

--- a/src/cleanup_with_absolute_prefix_unittest.cc
+++ b/src/cleanup_with_absolute_prefix_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Google Inc.
+// Copyright (c) 2024, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -55,7 +55,8 @@ using testing::StrNe;
 using namespace google;
 
 TEST(CleanImmediatelyWithAbsolutePrefix, logging) {
-  google::EnableLogCleaner(0);
+  using namespace std::chrono_literals;
+  google::EnableLogCleaner(0h);
   google::SetLogFilenameExtension(".barfoo");
   google::SetLogDestination(GLOG_INFO, "test_cleanup_");
 

--- a/src/cleanup_with_relative_prefix_unittest.cc
+++ b/src/cleanup_with_relative_prefix_unittest.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, Google Inc.
+// Copyright (c) 2024, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -55,7 +55,8 @@ using testing::StrNe;
 using namespace google;
 
 TEST(CleanImmediatelyWithRelativePrefix, logging) {
-  google::EnableLogCleaner(0);
+  using namespace std::chrono_literals;
+  google::EnableLogCleaner(0h);
   google::SetLogFilenameExtension(".relativefoo");
   google::SetLogDestination(GLOG_INFO, "test_subdir/test_cleanup_");
 

--- a/src/glog/logging.h
+++ b/src/glog/logging.h
@@ -497,8 +497,12 @@ typedef void (*logging_fail_func_t)();
 // Install a function which will be called after LOG(FATAL).
 GLOG_EXPORT void InstallFailureFunction(logging_fail_func_t fail_func);
 
+[[deprecated(
+    "Use the type-safe std::chrono::minutes EnableLogCleaner overload "
+    "instead.")]] GLOG_EXPORT void
+EnableLogCleaner(unsigned int overdue_days);
 // Enable/Disable old log cleaner.
-GLOG_EXPORT void EnableLogCleaner(unsigned int overdue_days);
+GLOG_EXPORT void EnableLogCleaner(const std::chrono::minutes& overdue);
 GLOG_EXPORT void DisableLogCleaner();
 GLOG_EXPORT void SetApplicationFingerprint(const std::string& fingerprint);
 


### PR DESCRIPTION
* Deprecate type-unsafe EnableLogCleaner interface
* Increase time resolution allowing to drop timing specific workarounds in unit tests