### PR TITLE
Add r-value overload to LogMessageVoidify to make clang-17 happy with c++20

### DIFF
--- a/src/glog/logging.h
+++ b/src/glog/logging.h
@@ -1471,6 +1471,7 @@ struct LogMessageVoidify {
   // This has to be an operator with a precedence lower than << but
   // higher than ?:
   void operator&(std::ostream&) noexcept {}
+  void operator&(std::ostream&&) noexcept {}
 };
 
 }  // namespace internal


### PR DESCRIPTION
Without this, compilation fails for errors like the following

```
bazel-out/k8-opt/bin/external/com_google_glog/_virtual_includes/glog/glog/logging.h:705:57: note: expanded from macro 'LOG_IF'
  705 |   !(condition) ? (void) 0 : google::LogMessageVoidify() & LOG(severity)
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
external/local_config_clang/crosstool/extra_tools/lib/gcc/x86_64-linux-gnu/13.2.0/../../../../include/c++/13.2.0/cstddef:140:3: note: candidate function not viable: no known conversion from 'google::LogMessageVoidify' to 'byte' for 1st argument
  140 |   operator&(byte __l, byte __r) noexcept
      |   ^         ~~~~~~~~
external/local_config_clang/crosstool/extra_tools/lib/gcc/x86_64-linux-gnu/13.2.0/../../../../include/c++/13.2.0/bits/ios_base.h:83:3: note: candidate function not viable: no known conversion from 'google::LogMessageVoidify' to '_Ios_Fmtflags' for 1st argument
   83 |   operator&(_Ios_Fmtflags __a, _Ios_Fmtflags __b)
      |   ^         ~~~~~~~~~~~~~~~~~
external/local_config_clang/crosstool/extra_tools/lib/gcc/x86_64-linux-gnu/13.2.0/../../../../include/c++/13.2.0/bits/ios_base.h:126:3: note: candidate function not viable: no known conversion from 'google::LogMessageVoidify' to '_Ios_Openmode' for 1st argument
  126 |   operator&(_Ios_Openmode __a, _Ios_Openmode __b)
      |   ^         ~~~~~~~~~~~~~~~~~
external/local_config_clang/crosstool/extra_tools/lib/gcc/x86_64-linux-gnu/13.2.0/../../../../include/c++/13.2.0/bits/ios_base.h:166:3: note: candidate function not viable: no known conversion from 'google::LogMessageVoidify' to '_Ios_Iostate' for 1st argument
  166 |   operator&(_Ios_Iostate __a, _Ios_Iostate __b)
      |   ^         ~~~~~~~~~~~~~~~~
external/local_config_clang/crosstool/extra_tools/lib/gcc/x86_64-linux-gnu/13.2.0/../../../../include/c++/13.2.0/bits/atomic_base.h:107:3: note: candidate function not viable: no known conversion from 'google::LogMessageVoidify' to 'memory_order' for 1st argument
  107 |   operator&(memory_order __m, __memory_order_modifier __mod)
      |   ^         ~~~~~~~~~~~~~~~~
external/local_config_clang/crosstool/extra_tools/lib/gcc/x86_64-linux-gnu/13.2.0/../../../../include/c++/13.2.0/future:155:20: note: candidate function not viable: no known conversion from 'google::LogMessageVoidify' to 'launch' for 1st argument
  155 |   constexpr launch operator&(launch __x, launch __y) noexcept
      |                    ^         ~~~~~~~~~~
external/local_config_clang/crosstool/extra_tools/lib/gcc/x86_64-linux-gnu/13.2.0/../../../../include/c++/13.2.0/charconv:645:3: note: candidate function not viable: no known conversion from 'google::LogMessageVoidify' to 'chars_format' for 1st argument
  645 |   operator&(chars_format __lhs, chars_format __rhs) noexcept
      |   ^         ~~~~~~~~~~~~~~~~~~
external/local_config_clang/crosstool/extra_tools/lib/gcc/x86_64-linux-gnu/13.2.0/../../../../include/c++/13.2.0/bitset:1553:5: note: candidate template ignored: could not match 'bitset<_Nb>' against 'google::LogMessageVoidify'
 1553 |     operator&(const bitset<_Nb>& __x, const bitset<_Nb>& __y) _GLIBCXX_NOEXCEPT
      |     ^
bazel-out/k8-opt/bin/external/com_google_glog/_virtual_includes/glog/glog/logging.h:1717:8: note: candidate function not viable: expects an lvalue for 1st argument
 1717 |   void operator&(std::ostream&) { }
      |        ^         ~~~~~~~~~~~
```