### PR TITLE
Fixed IsLogFromCurrentProject to include all severities

### DIFF
--- a/src/cleanup_immediately_unittest.cc
+++ b/src/cleanup_immediately_unittest.cc
@@ -60,7 +60,7 @@ TEST(CleanImmediately, logging) {
   google::EnableLogCleaner(0h);
 
   for (unsigned i = 0; i < 1000; ++i) {
-    LOG(INFO) << "cleanup test";
+    LOG(WARNING) << "cleanup test";
   }
 
   google::DisableLogCleaner();

--- a/src/cleanup_with_relative_prefix_unittest.cc
+++ b/src/cleanup_with_relative_prefix_unittest.cc
@@ -61,7 +61,7 @@ TEST(CleanImmediatelyWithRelativePrefix, logging) {
   google::SetLogDestination(GLOG_INFO, "test_subdir/test_cleanup_");
 
   for (unsigned i = 0; i < 1000; ++i) {
-    LOG(INFO) << "cleanup test";
+    LOG(ERROR) << "cleanup test";
   }
 
   google::DisableLogCleaner();


### PR DESCRIPTION
Previously when executing following code LogCleaner would only delete overdue Error log files:
```
google::EnableLogCleaner(1min);

LOG(ERROR) << "Error hello";
LOG(INFO) << "Info hello";
LOG(WARNING) << "Warning hello";
```
And if we changed the order to for example:
```
LOG(INFO) << "Info hello";
LOG(ERROR) << "Error hello";
LOG(WARNING) << "Warning hello";
```
LogCleaner would only delete overdue Info log files and overdue Error and Warning files were ignored.
To include all severities during LogCleaner's sweep I tested filepath for all severities in a IsLogFromCurrentProject function. 