### PR TITLE
feat: allow to obtain the stack trace as a string

### DIFF
--- a/src/glog/logging.h
+++ b/src/glog/logging.h
@@ -1733,6 +1733,9 @@ GLOG_EXPORT bool IsFailureSignalHandlerInstalled();
 GLOG_EXPORT void InstallFailureWriter(void (*writer)(const char* data,
                                                      size_t size));
 
+// Dump stack trace as a string.
+GLOG_EXPORT std::string GetStackTrace();
+
 }  // namespace google
 
 #endif  // GLOG_LOGGING_H

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1705,8 +1705,7 @@ void LogMessage::Init(const char* file, int line, LogSeverity severity,
     std::snprintf(fileline, sizeof(fileline), "%s:%d", data_->basename_, line);
 #ifdef HAVE_STACKTRACE
     if (FLAGS_log_backtrace_at == fileline) {
-      string stacktrace;
-      DumpStackTraceToString(&stacktrace);
+      string stacktrace = GetStackTrace();
       stream() << " (stacktrace:\n" << stacktrace << ") ";
     }
 #endif

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -287,12 +287,6 @@ static void MyUserNameInitializer() {
 }
 REGISTER_MODULE_INITIALIZER(utilities, MyUserNameInitializer())
 
-#ifdef HAVE_STACKTRACE
-void DumpStackTraceToString(string* stacktrace) {
-  DumpStackTrace(1, DebugWriteToString, stacktrace);
-}
-#endif
-
 // We use an atomic operation to prevent problems with calling CrashReason
 // from inside the Mutex implementation (potentially through RAW_CHECK).
 static std::atomic<const logging::internal::CrashReason*> g_reason{nullptr};
@@ -323,4 +317,13 @@ void ShutdownGoogleLoggingUtilities() {
 }
 
 }  // namespace glog_internal_namespace_
+
+#ifdef HAVE_STACKTRACE
+std::string GetStackTrace() {
+  std::string stacktrace;
+  DumpStackTrace(1, DebugWriteToString, &stacktrace);
+  return stacktrace;
+}
+#endif
+
 }  // namespace google

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -162,8 +162,6 @@ const std::string& MyUserName();
 // (Doesn't modify filepath, contrary to basename() in libgen.h.)
 const char* const_basename(const char* filepath);
 
-void DumpStackTraceToString(std::string* stacktrace);
-
 void SetCrashReason(const logging::internal::CrashReason* r);
 
 void InitGoogleLoggingUtilities(const char* argv0);


### PR DESCRIPTION
Expose `DumpStackTraceToString` as `GetStackTrace`.

Resolves #144