### PR TITLE
HAVE_SYMBOLIZE not defined when HAVE_LINK_H is

### DIFF
--- a/src/symbolize.h
+++ b/src/symbolize.h
@@ -80,7 +80,7 @@
 #ifndef GLOG_NO_SYMBOLIZE_DETECTION
 #  ifndef HAVE_SYMBOLIZE
 // defined by gcc
-#    if defined(HAVE_ELF_H) || defined(HAVE_SYS_EXEC_ELF_H)
+#    if defined(HAVE_ELF_H) || defined(HAVE_SYS_EXEC_ELF_H) || defined(HAVE_LINK_H)
 #      define HAVE_SYMBOLIZE
 #    elif defined(GLOG_OS_MACOSX) && defined(HAVE_DLADDR)
 // Use dladdr to symbolize.


### PR DESCRIPTION
Fixing issue #1084 . We are trying to bump glog up to latest version using bazel in our project.

In glog.bzl, there's HAVE_LINK_H defined. However, in symbolize.h, it doesn't lead
to defining HAVE_SYMBOLIZE, resulting in the error
```
warning: Symbolize functionality is not available for target platform: stack dump will contain empty frames. [-W#pragma-messages]
#  pragma message( \
          ^
1 warning generated.
```