### PR TITLE
Incorrect stack trace for stripped binaries

### DIFF
--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -642,18 +642,13 @@ OpenObjectFileContainingPcAndGetStartAddress(uint64_t pc,
       return nullptr;  // Malformed line.
     }
 
+    strncpy(out_file_name, cursor, out_file_name_size);
+    // Making sure |out_file_name| is always null-terminated.
+    out_file_name[out_file_name_size - 1] = '\0';
+
     // Finally, "cursor" now points to file name of our interest.
-    FileDescriptor object_fd{
+    return FileDescriptor{
         FailureRetry([cursor] { return open(cursor, O_RDONLY); })};
-    if (!object_fd) {
-      // Failed to open object file.  Copy the object file name to
-      // |out_file_name|.
-      strncpy(out_file_name, cursor, out_file_name_size);
-      // Making sure |out_file_name| is always null-terminated.
-      out_file_name[out_file_name_size - 1] = '\0';
-      return nullptr;
-    }
-    return object_fd;
   }
 }
 


### PR DESCRIPTION
If the executable is stripped, I expect the `FailureSignalHandler` to dump module+offset for each stack frame, but the output is always `(unknown)`.
Seems like this is because of a typo in `OpenObjectFileContainingPcAndGetStartAddress`.

Code to reproduce:
[repro.zip](https://github.com/google/glog/files/14825377/repro.zip)
Just extract and run `./run_test.py` on the host (docker and python3 are required).

**Expected output**
```
    @     0x7fa3c2b86699 __cxa_throw
    @     0x55a4ed24f389 (/build/testbin-stripped+0x2388)
    @     0x55a4ed24f3c6 main
```
**Actual output**
```
    @     0x7f81b4790699 __cxa_throw
    @     0x5645b9032389 (unknown)
    @     0x5645b90323c6 main
```