### PR TITLE
Fix comment NOTE about SetVLOGLevel

### DIFF
--- a/src/glog/vlog_is_on.h
+++ b/src/glog/vlog_is_on.h
@@ -103,11 +103,10 @@ namespace google {
 // Set VLOG(_IS_ON) level for module_pattern to log_level.
 // This lets us dynamically control what is normally set by the --vmodule flag.
 // Returns the level that previously applied to module_pattern.
-// NOTE: To change the log level for VLOG(_IS_ON) sites
-//	 that have already executed after/during InitGoogleLogging,
-//	 one needs to supply the exact --vmodule pattern that applied to them.
-//       (If no --vmodule pattern applied to them
-//       the value of FLAGS_v will continue to control them.)
+// NOTE: To change the log level for VLOG(_IS_ON) sites that matched a prior
+// --vmodule pattern then the exact pattern has to be supplied again. (If no
+// --vmodule pattern applied to them before then the first matching pattern will
+// start to control them.)
 extern GLOG_EXPORT int SetVLOGLevel(const char* module_pattern, int log_level);
 
 // Various declarations needed for VLOG_IS_ON above: =========================


### PR DESCRIPTION
Fix the comment about `SetVLOGLevel` according to https://github.com/google/glog/pull/650 which added support for updating vmodule levels after vmodule level has been cached.

Fixes https://github.com/google/glog/issues/858