### PR TITLE
feat(symbolize): Symbolize detection support HAVE_LINK_H

### DIFF
--- a/src/symbolize.h
+++ b/src/symbolize.h
@@ -82,6 +82,9 @@
 // defined by gcc
 #    if defined(HAVE_ELF_H) || defined(HAVE_SYS_EXEC_ELF_H)
 #      define HAVE_SYMBOLIZE
+// provided by glibc
+#    elif defined(HAVE_LINK_H)
+#      define HAVE_SYMBOLIZE
 #    elif defined(GLOG_OS_MACOSX) && defined(HAVE_DLADDR)
 // Use dladdr to symbolize.
 #      define HAVE_SYMBOLIZE


### PR DESCRIPTION
`link.h` is usually provided by glibc. Current implementation of symbolize can work on `link.h`. Enhance the symbolize detection logic to support `link.h`, AKA. define `HAVE_SYMBOLIZE` if `defined(HAVE_LINK_H)`.

This PR close #1084 and supersede #1085.

There's a few discussion in #1085 about why make changes in `src/symbolize.h` instead of `bazel/glog.bzl`. My justification is that this is an enhancement to symbolize detection logic rather than an alignment between bazel and cmake build systems. `link.h` can provide us `ElfW` thus can support our implementation.

I would like to open a separate issue if we still want to discuss whether we should define `HAVE_SYMBOLIZE` in `bazel/glog.bzl`.