### PR TITLE
feat(symbolize): Bazel build system define HAVE_SYMBOLIZE

### DIFF
--- a/bazel/glog.bzl
+++ b/bazel/glog.bzl
@@ -91,12 +91,14 @@ def glog_library(with_gflags = 1, **kwargs):
         # Enable declaration of _Unwind_Backtrace
         "-D_GNU_SOURCE",
         "-DHAVE_LINK_H",
+        "-DHAVE_SYMBOLIZE",  # Supported by <link.h>
     ]
 
     linux_only_copts = [
         # For utilities.h.
         "-DHAVE_EXECINFO_H",
         "-DHAVE_LINK_H",
+        "-DHAVE_SYMBOLIZE",  # Supported by <link.h>
     ]
 
     darwin_only_copts = [

--- a/src/symbolize.h
+++ b/src/symbolize.h
@@ -77,6 +77,10 @@
 #  error "symbolize.h" was not included correctly.
 #endif
 
+// We prefer to let the build system detect the availability of certain features
+// such as symbolization support. HAVE_SYMBOLIZE should therefore be defined by
+// the build system in general unless there is a good reason to perform the
+// detection using the preprocessor.
 #ifndef GLOG_NO_SYMBOLIZE_DETECTION
 #  ifndef HAVE_SYMBOLIZE
 // defined by gcc


### PR DESCRIPTION
`link.h` is usually provided by glibc. Current implementation of symbolize can work on `link.h`. Enhance the symbolize detection logic to support `link.h` by defining HAVE_SYMBOLIZE in bazel build description file.

The choice of altering bazel build file is for the following reasons

1. "glog moved away from using preprocessor logic in recent releases because this approach is error prone. Contributions are expected to follow the methodology for consistency reasons." according to @sergiud 
2. CMake build file have supported it.

This PR close https://github.com/google/glog/issues/1084, supersede https://github.com/google/glog/pull/1085 and https://github.com/google/glog/pull/1114. It also fixes https://github.com/google/glog/issues/1111.