### PR TITLE
Fix Windows Clang-CL build with Bazel@HEAD

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,3 +5,8 @@ module(
 
 bazel_dep(name = "gflags", version = "2.2.2")
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)
+bazel_dep(name = "platforms", version = "0.0.10")
+
+# Required for Windows clang-cl build: --extra_toolchains=@local_config_cc//:cc-toolchain-arm64_windows
+cc_configure = use_extension("@bazel_tools//tools/cpp:cc_configure.bzl", "cc_configure_extension")
+use_repo(cc_configure, "local_config_cc")


### PR DESCRIPTION
With WORKSPACE being disabled at HEAD, all dependencies must be specified in MODULE.bazel

Fixing https://github.com/google/glog/issues/1127