### PR TITLE
Add LWP id to dump info

### DIFF
--- a/src/signalhandler.cc
+++ b/src/signalhandler.cc
@@ -55,6 +55,10 @@
 #ifdef HAVE_UNISTD_H
 #  include <unistd.h>
 #endif
+#if defined(HAVE_SYS_SYSCALL_H) && defined(HAVE_SYS_TYPES_H)
+#  include <sys/syscall.h>
+#  include <sys/types.h>
+#endif
 
 namespace google {
 
@@ -216,8 +220,14 @@ void DumpSignalInfo(int signal_number, siginfo_t* siginfo) {
   std::ostringstream oss;
   oss << std::showbase << std::hex << std::this_thread::get_id();
   formatter.AppendString(oss.str().c_str());
-
+#  if defined(GLOG_OS_LINUX) && defined(HAVE_SYS_SYSCALL_H) && \
+      defined(HAVE_SYS_TYPES_H)
+  pid_t tid = syscall(SYS_gettid);
+  formatter.AppendString(" LWP ");
+  formatter.AppendUint64(static_cast<uint64>(tid), 10);
+#  endif
   formatter.AppendString(") ");
+
   // Only linux has the PID of the signal sender in si_pid.
 #  ifdef GLOG_OS_LINUX
   formatter.AppendString("from PID ");


### PR DESCRIPTION
LWP can help gdb find the corresponding thread more quickly.

```
*** SIGSEGV (@0xff) received by PID 2699683 (TID 0x7f342020a640 LWP 2700477) from PID 255; stack trace: ***
    @     0x7f3501070ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
```