### PR TITLE
chore(security): avoid use of `strcpy`

### DIFF
--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -832,8 +832,10 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(
   Dl_info info;
   if (dladdr(pc, &info)) {
     if (info.dli_sname) {
-      if (strlen(info.dli_sname) < out_size) {
-        strcpy(out, info.dli_sname);
+      int name_length = strlen(info.dli_sname);
+      if (name_length < out_size) {
+        memcpy(out, info.dli_sname, name_length);
+        out[name_length] = '\0';
         // Symbolization succeeded.  Now we try to demangle the symbol.
         DemangleInplace(out, out_size);
         return true;

--- a/src/symbolize.cc
+++ b/src/symbolize.cc
@@ -834,8 +834,7 @@ static ATTRIBUTE_NOINLINE bool SymbolizeAndDemangle(
     if (info.dli_sname) {
       int name_length = strlen(info.dli_sname);
       if (name_length < out_size) {
-        memcpy(out, info.dli_sname, name_length);
-        out[name_length] = '\0';
+        strlcpy(out, info.dli_sname, name_length);
         // Symbolization succeeded.  Now we try to demangle the symbol.
         DemangleInplace(out, out_size);
         return true;


### PR DESCRIPTION
Internally, we use this library with React Native. We noticed that Xcode's static analysis would point out a potentially unsafe call to `strcpy`. We are doing a proper bound check, but to be safer, we could also use something like `strncpy` / `strncpy_s` / `strlcpy` / `memcpy` to handle this case. Of those, the latter felt the most portable, so I went with that. 