### PR TITLE
add check and set RTTI macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,18 @@ endif (WITH_FUZZING STREQUAL none)
 check_cxx_symbol_exists (__argv cstdlib HAVE___ARGV)
 check_cxx_symbol_exists (getprogname cstdlib HAVE_GETPROGNAME)
 check_cxx_symbol_exists (program_invocation_short_name cerrno HAVE_PROGRAM_INVOCATION_SHORT_NAME)
+
+check_cxx_source_compiles([=[
+  #include <typeinfo>
+  int main() { typeid(int); return 0; }
+]=] HAVE_RTTI)
+
+if(HAVE_RTTI)
+  set(DISABLE_RTTI OFF)
+else()
+  set(DISABLE_RTTI ON)
+endif()
+
 check_cxx_source_compiles ([=[
 #include <cstdlib>
 extern char* __progname;

--- a/src/config.h.cmake.in
+++ b/src/config.h.cmake.in
@@ -1,6 +1,9 @@
 #ifndef GLOG_CONFIG_H
 #define GLOG_CONFIG_H
 
+/* define if glog doesn't use RTTI */
+#cmakedefine DISABLE_RTTI
+
 /* Define if you have the `dladdr' function */
 #cmakedefine HAVE_DLADDR
 


### PR DESCRIPTION
I noticed that ``DISABLE_RTTI`` was used in ``src/logging.cc``, but ``DISABLE_RTTI`` was not set. 
If RTTI is disabled at compile time (for example,`` g++ -fno-rtti``), it will cause an error.